### PR TITLE
Add an initial state to Solver before adding external loads

### DIFF
--- a/docs/user_guide/ug_deformation.md
+++ b/docs/user_guide/ug_deformation.md
@@ -1,0 +1,31 @@
+# Deformation
+
+The deformation class implements the cable deformation models described in [Cable modeling](ug_cable_model.md#physics-based-cable-model).
+
+This class is called in two situations:
+
+- When computing $L_{ref}$, which is done only one time
+- When solving the new state after giving new wind pressure, ice thickness and temperature in `cable_state.py`. In this case, the solver calls `IDeformation` many times in order to find the solution
+
+In the former case, the computation is made without wind, ice, and class attribute `current_temperature` is equal to `sagging_temperature` (usually 15°C). That is why `current_temperature` equals to `sagging_temperature` by default when creating the class.
+
+In the latter case, the wind and ice are taken into account through `load_coefficient`, the new temperature is given directly by changing the attribute `current_temperature` of `IDeformation`
+
+```python
+
+data_container = factory_data_container(section_array, cable_array, weather_array)
+data_container.sagging_temperature = 15
+
+# create Deformation with initial state, current_temperature is set to sagging_temperature
+deformation_model = DeformationRte(
+	**data_container.__dict__,
+	tension_mean=tension_mean,
+	cable_length=cable_length,
+)
+deformation_model.current_temperature
+# 15
+
+
+# input new temperature after a state change
+deformation_model.current_temperature = 25
+```

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -43,6 +43,7 @@ nav:
       - Input data format: user_guide/ug_input.md
       - Cable modelling : user_guide/ug_cable_model.md
       - Sag-tension calculation : user_guide/ug_sag_tension_calc.md
+      - Deformation : user_guide/ug_deformation.md
       - Configuration : user_guide/ug_configuration.md
   - Developer guide:
     - API Reference:

--- a/src/mechaphlowers/api/state.py
+++ b/src/mechaphlowers/api/state.py
@@ -36,21 +36,4 @@ class StateAccessor:
 			raise ValueError(
 				"Deformation model is not defined: setting cable usually sets deformation model"
 			)
-		# if isinstance(current_temperature, (float, int)):
-		# 	current_temperature = np.full(
-		# 		self.frame.section_array.data.shape[0],
-		# 		float(current_temperature),
-		# 	)
-		# if not isinstance(current_temperature, np.ndarray):
-		# 	raise ValueError(
-		# 		"Current temperature should be a float or an array"
-		# 	)
-		# if isinstance(current_temperature, np.ndarray):
-		# 	if (
-		# 		current_temperature.shape[0]
-		# 		!= self.frame.section_array.data.shape[0]
-		# 	):
-		# 		raise ValueError(
-		# 			"Current temperature should have the same length as the section"
-		# 		)
 		return self.frame.deformation.L_ref()

--- a/src/mechaphlowers/api/state.py
+++ b/src/mechaphlowers/api/state.py
@@ -20,7 +20,7 @@ class StateAccessor:
 	def __init__(self, frame: SectionDataFrame):
 		self.frame: SectionDataFrame = frame
 
-	def L_ref(self, current_temperature: float | np.ndarray) -> np.ndarray:
+	def L_ref(self) -> np.ndarray:
 		"""L_ref values for the current temperature
 
 		Args:
@@ -36,21 +36,21 @@ class StateAccessor:
 			raise ValueError(
 				"Deformation model is not defined: setting cable usually sets deformation model"
 			)
-		if isinstance(current_temperature, (float, int)):
-			current_temperature = np.full(
-				self.frame.section_array.data.shape[0],
-				float(current_temperature),
-			)
-		if not isinstance(current_temperature, np.ndarray):
-			raise ValueError(
-				"Current temperature should be a float or an array"
-			)
-		if isinstance(current_temperature, np.ndarray):
-			if (
-				current_temperature.shape[0]
-				!= self.frame.section_array.data.shape[0]
-			):
-				raise ValueError(
-					"Current temperature should have the same length as the section"
-				)
-		return self.frame.deformation.L_ref(current_temperature)
+		# if isinstance(current_temperature, (float, int)):
+		# 	current_temperature = np.full(
+		# 		self.frame.section_array.data.shape[0],
+		# 		float(current_temperature),
+		# 	)
+		# if not isinstance(current_temperature, np.ndarray):
+		# 	raise ValueError(
+		# 		"Current temperature should be a float or an array"
+		# 	)
+		# if isinstance(current_temperature, np.ndarray):
+		# 	if (
+		# 		current_temperature.shape[0]
+		# 		!= self.frame.section_array.data.shape[0]
+		# 	):
+		# 		raise ValueError(
+		# 			"Current temperature should have the same length as the section"
+		# 		)
+		return self.frame.deformation.L_ref()

--- a/src/mechaphlowers/api/state.py
+++ b/src/mechaphlowers/api/state.py
@@ -43,24 +43,6 @@ class StateAccessor:
 				"Deformation model is not defined: setting cable usually sets deformation model"
 			)
 		return self.frame.deformation.L_ref()
-		# if isinstance(current_temperature, (float, int)):
-		# 	current_temperature = np.full(
-		# 		self.frame.section_array.data.shape[0],
-		# 		float(current_temperature),
-		# 	)
-		# if not isinstance(current_temperature, np.ndarray):
-		# 	raise ValueError(
-		# 		"Current temperature should be a float or an array"
-		# 	)
-		# if isinstance(current_temperature, np.ndarray):
-		# 	if (
-		# 		current_temperature.shape[0]
-		# 		!= self.frame.section_array.data.shape[0]
-		# 	):
-		# 		raise ValueError(
-		# 			"Current temperature should have the same length as the section"
-		# 		)
-		# return self.frame.deformation.L_ref(current_temperature)
 
 	def change(
 		self, current_temperature: np.ndarray, weather_loads: WeatherArray
@@ -74,7 +56,9 @@ class StateAccessor:
 				"Deformation model is not defined: setting cable usually sets deformation model"
 			)
 
-		sag_tension_calculation = SagTensionSolver(**self.frame.data_container.__dict__,)
+		sag_tension_calculation = SagTensionSolver(
+			**self.frame.data_container.__dict__,
+		)
 		sag_tension_calculation.initial_state()
 		sag_tension_calculation.change_state(
 			**weather_loads.to_numpy(),

--- a/src/mechaphlowers/core/models/cable/deformation.py
+++ b/src/mechaphlowers/core/models/cable/deformation.py
@@ -39,7 +39,7 @@ class IDeformation(ABC):
 		self.dilatation_coefficient = dilatation_coefficient
 		self.temp_ref = temperature_reference
 		self.polynomial_conductor = polynomial_conductor
-		self.sagging_temperature = sagging_temperature
+		self.current_temperature = sagging_temperature
 
 		if max_stress is None:
 			self.max_stress = np.full(self.cable_length.shape, 0)
@@ -100,7 +100,7 @@ class DeformationRte(IDeformation):
 		return self.epsilon_mecha() + self.epsilon_therm()
 
 	def epsilon_therm(self) -> np.ndarray:
-		sagging_temperature = self.sagging_temperature
+		sagging_temperature = self.current_temperature
 		temp_ref = self.temp_ref
 		alpha = self.dilatation_coefficient
 		return self.compute_epsilon_therm(sagging_temperature, temp_ref, alpha)

--- a/src/mechaphlowers/core/solver/cable_state.py
+++ b/src/mechaphlowers/core/solver/cable_state.py
@@ -35,6 +35,7 @@ class SagTensionSolver:
 		span_length: np.ndarray,
 		elevation_difference: np.ndarray,
 		sagging_parameter: np.ndarray,
+		sagging_temperature: np.ndarray,
 		cable_section_area: np.float64,
 		diameter: np.float64,
 		linear_weight: np.float64,
@@ -47,6 +48,7 @@ class SagTensionSolver:
 		self.span_length = span_length
 		self.elevation_difference = elevation_difference
 		self.sagging_parameter = sagging_parameter
+		self.sagging_temperature = sagging_temperature
 		self.cable_section_area = cable_section_area
 		self.diameter = diameter
 		self.linear_weight = linear_weight
@@ -68,15 +70,11 @@ class SagTensionSolver:
 		self.span_length_after_loads = span_length
 		self.elevation_difference_after_loads = elevation_difference
 
-	def initial_state(
-		self, current_temperature: np.ndarray
-	) -> None:  # TODO: check on proto if sagging temperature here
+	def initial_state(self) -> None:
 		"""Method that computes the unstressed length and the initial horizontal tension of the cable without any external loads.
 		Store those two values in the class attributes.
 		It should be called after the initialization of the class.
 
-		Args:
-			current_temperature (np.ndarray): _description_
 		"""
 		initial_span_model = self.span_model_type(
 			self.span_length,
@@ -93,7 +91,7 @@ class SagTensionSolver:
 			tension_mean=tension_mean,
 			cable_length=cable_length,
 		)
-		self.L_ref = initial_deformation_model.L_ref(current_temperature)
+		self.L_ref = initial_deformation_model.L_ref(self.sagging_temperature)
 		self.T_h_after_change = initial_span_model.T_h()
 
 	def update_loads(

--- a/src/mechaphlowers/core/solver/cable_state.py
+++ b/src/mechaphlowers/core/solver/cable_state.py
@@ -91,7 +91,7 @@ class SagTensionSolver:
 			tension_mean=tension_mean,
 			cable_length=cable_length,
 		)
-		self.L_ref = initial_deformation_model.L_ref(self.sagging_temperature)
+		self.L_ref = initial_deformation_model.L_ref()
 		self.T_h_after_change = initial_span_model.T_h()
 
 	def update_loads(

--- a/src/mechaphlowers/core/solver/cable_state.py
+++ b/src/mechaphlowers/core/solver/cable_state.py
@@ -68,15 +68,25 @@ class SagTensionSolver:
 		self.span_length_after_loads = span_length
 		self.elevation_difference_after_loads = elevation_difference
 
-	def initial_state(self, current_temperature) -> None:  # TODO: check on proto if sagging temperature here
+	def initial_state(
+		self, current_temperature
+	) -> None:  # TODO: check on proto if sagging temperature here
 		"""Method that computes the initial horizontal tension of the cable."""
 		# load coefficient used comes from the default CableLoads: should be equal to 1
 		initial_span_model = self.span_model_type(
-			self.span_length, self.elevation_difference, self.sagging_parameter, load_coefficient=self.cable_loads.load_coefficient, linear_weight=self.linear_weight
+			self.span_length,
+			self.elevation_difference,
+			self.sagging_parameter,
+			load_coefficient=self.cable_loads.load_coefficient,
+			linear_weight=self.linear_weight,
 		)
 		cable_length = initial_span_model.L()
 		tension_mean = initial_span_model.T_mean()
-		initial_deformation_model = self.deformation_model_type(**self.__dict__, tension_mean=tension_mean, cable_length=cable_length)
+		initial_deformation_model = self.deformation_model_type(
+			**self.__dict__,
+			tension_mean=tension_mean,
+			cable_length=cable_length,
+		)
 		self.L_ref = initial_deformation_model.L_ref(current_temperature)
 
 	def update_loads(

--- a/test/api/test_frames.py
+++ b/test/api/test_frames.py
@@ -98,7 +98,7 @@ def test_SectionDataFrame__state(
 	frame = SectionDataFrame(default_section_array_three_spans)
 	frame.add_cable(default_cable_array)
 	assert np.array_equal(
-		frame.state.L_ref(12), frame.deformation.L_ref(12), equal_nan=True
+		frame.state.L_ref(), frame.deformation.L_ref(), equal_nan=True
 	)
 
 

--- a/test/api/test_state.py
+++ b/test/api/test_state.py
@@ -11,8 +11,8 @@ from mechaphlowers.api.state import StateAccessor
 
 
 class MockDeformation:
-	def L_ref(self, current_temperature):
-		return current_temperature
+	def L_ref(self):
+		return np.array([1, 2, 3])
 
 
 class MockSection:
@@ -37,41 +37,35 @@ def section_dataframe():
 
 def test_Deformation_is_not_defined(section_dataframe_without_deformation):
 	state_accessor = StateAccessor(section_dataframe_without_deformation)
-	with pytest.raises(
-		ValueError,
-	):
-		state_accessor.L_ref(25.0)
-
-
-def test_L_ref_with_wrong_type(section_dataframe):
-	state_accessor = StateAccessor(section_dataframe)
-	current_temperature = "25.0"
 	with pytest.raises(ValueError):
-		state_accessor.L_ref(current_temperature)
+		state_accessor.L_ref()
 
 
-def test_L_ref_with_float_or_int(section_dataframe):
+def test_L_ref_value(section_dataframe):
 	state_accessor = StateAccessor(section_dataframe)
-	current_temperature = 25.0
-	result = state_accessor.L_ref(current_temperature)
-	current_temperature = 25
-	result = state_accessor.L_ref(current_temperature)
-	expected = np.full(5, current_temperature)
+	result = state_accessor.L_ref()
+	expected = np.array([1, 2, 3])
 	np.testing.assert_array_equal(result, expected)
 
 
-def test_L_ref_with_correct_array(section_dataframe):
-	state_accessor = StateAccessor(section_dataframe)
-	current_temperature = np.array([25.0, 26.0, 27.0, 28.0, 29.0])
-	result = state_accessor.L_ref(current_temperature)
-	np.testing.assert_array_equal(result, current_temperature)
+# def test_L_ref_with_wrong_type(section_dataframe):
+# 	state_accessor = StateAccessor(section_dataframe)
+# 	current_temperature = "25.0"
+# 	with pytest.raises(ValueError):
+# 		state_accessor.L_ref()
+
+# def test_L_ref_with_correct_array(section_dataframe):
+# 	state_accessor = StateAccessor(section_dataframe)
+# 	current_temperature = np.array([25.0, 26.0, 27.0, 28.0, 29.0])
+# 	result = state_accessor.L_ref()
+# 	np.testing.assert_array_equal(result, current_temperature)
 
 
-def test_L_ref_with_incorrect_array_length(section_dataframe):
-	state_accessor = StateAccessor(section_dataframe)
-	current_temperature = np.array([25.0, 26.0])
-	with pytest.raises(
-		ValueError,
-		match="Current temperature should have the same length as the section",
-	):
-		state_accessor.L_ref(current_temperature)
+# def test_L_ref_with_incorrect_array_length(section_dataframe):
+# 	state_accessor = StateAccessor(section_dataframe)
+# 	current_temperature = np.array([25.0, 26.0])
+# 	with pytest.raises(
+# 		ValueError,
+# 		match="Current temperature should have the same length as the section",
+# 	):
+# 		state_accessor.L_ref()

--- a/test/api/test_state.py
+++ b/test/api/test_state.py
@@ -62,14 +62,6 @@ def test_L_ref_value(section_dataframe):
 	np.testing.assert_array_equal(result, expected)
 
 
-def test_L_ref_with_correct_array(section_dataframe):
-	state_accessor = StateAccessor(section_dataframe)
-	current_temperature = np.array([25.0, 26.0, 27.0, 28.0, 29.0])
-	result = state_accessor.L_ref(current_temperature)
-	np.testing.assert_array_equal(result, current_temperature)
-
-
-
 def test_change_without_deformation(
 	section_dataframe_without_deformation, weather_array
 ):

--- a/test/api/test_state.py
+++ b/test/api/test_state.py
@@ -46,26 +46,3 @@ def test_L_ref_value(section_dataframe):
 	result = state_accessor.L_ref()
 	expected = np.array([1, 2, 3])
 	np.testing.assert_array_equal(result, expected)
-
-
-# def test_L_ref_with_wrong_type(section_dataframe):
-# 	state_accessor = StateAccessor(section_dataframe)
-# 	current_temperature = "25.0"
-# 	with pytest.raises(ValueError):
-# 		state_accessor.L_ref()
-
-# def test_L_ref_with_correct_array(section_dataframe):
-# 	state_accessor = StateAccessor(section_dataframe)
-# 	current_temperature = np.array([25.0, 26.0, 27.0, 28.0, 29.0])
-# 	result = state_accessor.L_ref()
-# 	np.testing.assert_array_equal(result, current_temperature)
-
-
-# def test_L_ref_with_incorrect_array_length(section_dataframe):
-# 	state_accessor = StateAccessor(section_dataframe)
-# 	current_temperature = np.array([25.0, 26.0])
-# 	with pytest.raises(
-# 		ValueError,
-# 		match="Current temperature should have the same length as the section",
-# 	):
-# 		state_accessor.L_ref()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -55,7 +55,7 @@ def default_cable_array() -> CableArray:
 
 
 @pytest.fixture
-def default_section_array_one_spans() -> SectionArray:
+def default_section_array_one_span() -> SectionArray:
 	section_array = SectionArray(
 		pd.DataFrame(
 			{

--- a/test/core/models/cable/deformation_perf.py
+++ b/test/core/models/cable/deformation_perf.py
@@ -47,12 +47,16 @@ def test_solve_polynom_perf() -> None:
 	p = np.array([2_000] * spans_number)
 	lambd = np.float64(9.6)
 	m = np.array([1] * spans_number)
+	sagging_temperature = np.array([15] * spans_number)
 
 	span_model = CatenarySpan(a, b, p, load_coefficient=m, linear_weight=lambd)
 	tension_mean = span_model.T_mean()
 	cable_length = span_model.L()
 	deformation_model = DeformationRte(
-		**input_dict, tension_mean=tension_mean, cable_length=cable_length
+		**input_dict,
+		tension_mean=tension_mean,
+		cable_length=cable_length,
+		sagging_temperature=sagging_temperature,
 	)
 
 	start_time = time.time()

--- a/test/core/models/cable/test_deformation.py
+++ b/test/core/models/cable/test_deformation.py
@@ -44,16 +44,16 @@ def test_deformation_impl(
 		tension_mean=tension_mean,
 		cable_length=cable_length,
 	)
-	current_temperature = np.array([15, 15])
 	deformation_model.epsilon_mecha()
-	deformation_model.epsilon_therm(current_temperature)
-	deformation_model.epsilon(current_temperature)
-	deformation_model.L_ref(current_temperature)
+	deformation_model.epsilon_therm()
+	deformation_model.epsilon()
+	deformation_model.L_ref()
 
 
 def test_deformation_values__default_data(
 	default_data_container_one_span: DataContainer,
 ) -> None:
+	default_data_container_one_span.sagging_temperature = np.array([30, 30])
 	span_model = CatenarySpan(**default_data_container_one_span.__dict__)
 	tension_mean = span_model.T_mean()
 	cable_length = span_model.L()
@@ -63,11 +63,10 @@ def test_deformation_values__default_data(
 		tension_mean=tension_mean,
 		cable_length=cable_length,
 	)
-	current_temperature = np.array([30, 30])
 
 	eps_mecha = deformation_model.epsilon_mecha()
-	eps_therm = deformation_model.epsilon_therm(current_temperature)
-	L_ref = deformation_model.L_ref(current_temperature)
+	eps_therm = deformation_model.epsilon_therm()
+	L_ref = deformation_model.L_ref()
 
 	# Data given by the prototype
 	np.testing.assert_allclose(
@@ -103,7 +102,6 @@ def test_poly_deformation__degree_three(
 		tension_mean=tension_mean,
 		cable_length=cable_length,
 	)
-	current_temperature = np.array([15, 15])
 
 	constraint = (
 		tension_mean / default_data_container_one_span.cable_section_area
@@ -115,7 +113,7 @@ def test_poly_deformation__degree_three(
 	)
 	deformation_model.epsilon_mecha()
 
-	deformation_model.epsilon(current_temperature)
+	deformation_model.epsilon()
 
 
 def test_poly_deformation__degree_four(
@@ -135,7 +133,6 @@ def test_poly_deformation__degree_four(
 		tension_mean=tension_mean,
 		cable_length=cable_length,
 	)
-	current_temperature = np.array([15, 15])
 
 	constraint = (
 		tension_mean / default_data_container_one_span.cable_section_area
@@ -147,7 +144,7 @@ def test_poly_deformation__degree_four(
 	)
 	deformation_model.epsilon_mecha()
 
-	deformation_model.epsilon(current_temperature)
+	deformation_model.epsilon()
 
 
 def test_poly_deformation__degree_four__with_max_stress(
@@ -167,7 +164,6 @@ def test_poly_deformation__degree_four__with_max_stress(
 		tension_mean=tension_mean,
 		cable_length=cable_length,
 	)
-	current_temperature = np.array([15, 15])
 
 	constraint = (
 		tension_mean / default_data_container_one_span.cable_section_area
@@ -175,7 +171,7 @@ def test_poly_deformation__degree_four__with_max_stress(
 	constraint = np.fmax(constraint, np.array([0, 0]))
 	deformation_model.max_stress = np.array([1000, 1e8])
 	deformation_model.epsilon_mecha()
-	deformation_model.epsilon(current_temperature)
+	deformation_model.epsilon()
 
 
 def test_poly_deformation__no_solutions(
@@ -213,8 +209,7 @@ def test_deformation__data_container(
 		tension_mean=tension_mean,
 		cable_length=cable_length,
 	)
-	current_temperature = np.array([15, 15])
 	deformation_model.epsilon_mecha()
-	deformation_model.epsilon_therm(current_temperature)
-	deformation_model.epsilon(current_temperature)
-	deformation_model.L_ref(current_temperature)
+	deformation_model.epsilon_therm()
+	deformation_model.epsilon()
+	deformation_model.L_ref()

--- a/test/core/solver/test_cable_state.py
+++ b/test/core/solver/test_cable_state.py
@@ -134,12 +134,9 @@ def test_solver__bad_solver(
 def test_solver__values_before_solver(
 	default_data_container_one_span: DataContainer,
 ) -> None:
-	current_temperature = np.array([15] * 2)
-
 	sag_tension_calculation = SagTensionSolver(
 		**default_data_container_one_span.__dict__
 	)
-	sag_tension_calculation.initial_state(current_temperature)
 
 	assert sag_tension_calculation.T_h_after_change is None
 	with pytest.raises(ValueError):

--- a/test/core/solver/test_cable_state.py
+++ b/test/core/solver/test_cable_state.py
@@ -45,15 +45,12 @@ def test_solver__run_solver(
 	weather_dict_one_span: dict,
 ) -> None:
 	current_temperature = np.array([15] * 2)
-	unstressed_length = get_L_ref_from_arrays(
-		default_data_container_one_span,
-		current_temperature,
-	)
 
 	sag_tension_calculation = SagTensionSolver(
-		**default_data_container_one_span.__dict__,
-		unstressed_length=unstressed_length,
+		**default_data_container_one_span.__dict__
 	)
+	sag_tension_calculation.initial_state(current_temperature)
+
 	sag_tension_calculation.change_state(
 		**weather_dict_one_span,
 		temp=current_temperature,
@@ -82,15 +79,11 @@ def test_solver__run_solver__polynomial_model(
 	)
 	default_data_container_one_span.polynomial_conductor = new_poly
 
-	unstressed_length = get_L_ref_from_arrays(
-		default_data_container_one_span,
-		current_temperature,
-	)
-
 	sag_tension_calculation = SagTensionSolver(
-		**default_data_container_one_span.__dict__,
-		unstressed_length=unstressed_length,
+		**default_data_container_one_span.__dict__
 	)
+	sag_tension_calculation.initial_state(current_temperature)
+
 	sag_tension_calculation.change_state(
 		**weather_dict_one_span,
 		temp=current_temperature,
@@ -108,9 +101,10 @@ def test_solver__run_solver_no_solution(
 ) -> None:
 	current_temperature = np.array([15] * 2)
 	sag_tension_calculation = SagTensionSolver(
-		**default_data_container_one_span.__dict__,
-		unstressed_length=np.array([1, 1]),
+		**default_data_container_one_span.__dict__
 	)
+	sag_tension_calculation.initial_state(current_temperature)
+	sag_tension_calculation.L_ref = np.array([1, 1])
 	with pytest.raises(ValueError) as excinfo:
 		sag_tension_calculation.change_state(
 			**weather_dict_one_span, temp=current_temperature
@@ -123,16 +117,11 @@ def test_solver__bad_solver(
 	weather_dict_one_span: dict,
 ) -> None:
 	current_temperature = np.array([15] * 2)
-	unstressed_length = get_L_ref_from_arrays(
-		default_data_container_one_span,
-		current_temperature,
-	)
 
 	sag_tension_calculation = SagTensionSolver(
-		**default_data_container_one_span.__dict__,
-		unstressed_length=unstressed_length,
+		**default_data_container_one_span.__dict__
 	)
-
+	sag_tension_calculation.initial_state(current_temperature)
 	with pytest.raises(ValueError) as excinfo:
 		sag_tension_calculation.change_state(
 			**weather_dict_one_span,
@@ -146,15 +135,12 @@ def test_solver__values_before_solver(
 	default_data_container_one_span: DataContainer,
 ) -> None:
 	current_temperature = np.array([15] * 2)
-	unstressed_length = get_L_ref_from_arrays(
-		default_data_container_one_span,
-		current_temperature,
-	)
 
 	sag_tension_calculation = SagTensionSolver(
-		**default_data_container_one_span.__dict__,
-		unstressed_length=unstressed_length,
+		**default_data_container_one_span.__dict__
 	)
+	sag_tension_calculation.initial_state(current_temperature)
+
 	assert sag_tension_calculation.T_h_after_change is None
 	with pytest.raises(ValueError):
 		sag_tension_calculation.p_after_change()

--- a/test/core/solver/test_cable_state.py
+++ b/test/core/solver/test_cable_state.py
@@ -37,7 +37,7 @@ def get_L_ref_from_arrays(
 		tension_mean=span_model.T_mean(),
 		cable_length=span_model.L(),
 	)
-	return deformation.L_ref(current_temperature)
+	return deformation.L_ref()
 
 
 def test_solver__run_solver(

--- a/test/core/solver/test_cable_state.py
+++ b/test/core/solver/test_cable_state.py
@@ -49,7 +49,7 @@ def test_solver__run_solver(
 	sag_tension_calculation = SagTensionSolver(
 		**default_data_container_one_span.__dict__
 	)
-	sag_tension_calculation.initial_state(current_temperature)
+	sag_tension_calculation.initial_state()
 
 	sag_tension_calculation.change_state(
 		**weather_dict_one_span,
@@ -82,7 +82,7 @@ def test_solver__run_solver__polynomial_model(
 	sag_tension_calculation = SagTensionSolver(
 		**default_data_container_one_span.__dict__
 	)
-	sag_tension_calculation.initial_state(current_temperature)
+	sag_tension_calculation.initial_state()
 
 	sag_tension_calculation.change_state(
 		**weather_dict_one_span,
@@ -103,7 +103,7 @@ def test_solver__run_solver_no_solution(
 	sag_tension_calculation = SagTensionSolver(
 		**default_data_container_one_span.__dict__
 	)
-	sag_tension_calculation.initial_state(current_temperature)
+	sag_tension_calculation.initial_state()
 	sag_tension_calculation.L_ref = np.array([1, 1])
 	with pytest.raises(ValueError) as excinfo:
 		sag_tension_calculation.change_state(
@@ -121,7 +121,7 @@ def test_solver__bad_solver(
 	sag_tension_calculation = SagTensionSolver(
 		**default_data_container_one_span.__dict__
 	)
-	sag_tension_calculation.initial_state(current_temperature)
+	sag_tension_calculation.initial_state()
 	with pytest.raises(ValueError) as excinfo:
 		sag_tension_calculation.change_state(
 			**weather_dict_one_span,

--- a/test/core/solver/test_cable_state_integration.py
+++ b/test/core/solver/test_cable_state_integration.py
@@ -54,7 +54,7 @@ def test_functions_to_solve__same_loads(
 	frame = SectionDataFrame(default_section_array_three_spans)
 	frame.add_cable(default_cable_array)
 
-	weather_dict = {
+	weather_dict: WeatherDict = {
 		"ice_thickness": np.zeros(NB_SPAN),
 		"wind_pressure": np.zeros(NB_SPAN),
 	}

--- a/test/core/test_numeric.py
+++ b/test/core/test_numeric.py
@@ -247,6 +247,7 @@ def test_complex_halley():
 	assert_allclose(f(y, *coeffs), 0, atol=1e-6)
 
 
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_zero_der_nz_dp():
 	"""Test secant method with a non-zero dp, but an infinite newton step"""
 	# pick a symmetrical functions and choose a point on the side that with dx


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
Fixes #158 



**What kind of change does this PR introduce?**
Add `initial_state()` method to SagTensionSolver
Also done: remove argument `current_temperature` to deformation methods when computing L_ref: it refers to sagging_temperature


**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**
