### PR TITLE
Bugfix: using load_coefficient for display

### DIFF
--- a/src/mechaphlowers/api/frames.py
+++ b/src/mechaphlowers/api/frames.py
@@ -230,7 +230,7 @@ class SectionDataFrame:
     def update_weather(self) -> None:
         """update_weather method to update the weather-related properties"""
         self.cable_loads = CableLoads(**self.data_container.__dict__)  # type: ignore[union-attr,arg-type]
-        self.span.load_coefficient = self.cable_loads.load_coefficient  # type: ignore[union-attr]
+        self.span.load_coefficient = self.cable_loads.load_coefficient  # type: ignore[union-attr] # ???do this here?
         self.init_deformation_model()
 
     # How to manage case where type_var = SectionArray

--- a/src/mechaphlowers/api/state.py
+++ b/src/mechaphlowers/api/state.py
@@ -69,3 +69,4 @@ class StateAccessor:
         self.p_after_change = sag_tension_calculation.p_after_change()
         self.L_after_change = sag_tension_calculation.L_after_change()
         self.T_h_after_change = sag_tension_calculation.T_h_after_change
+        self.frame.span.sagging_parameter = self.p_after_change

--- a/src/mechaphlowers/entities/arrays.py
+++ b/src/mechaphlowers/entities/arrays.py
@@ -94,9 +94,13 @@ class SectionArray(ElementArray):
                 "Cannot return data: sagging_parameter and sagging_temperature are needed"
             )
         else:
+            sagging_parameter = np.repeat(
+                np.float64(self.sagging_parameter), self._data.shape[0]
+            )
+            sagging_parameter[-1] = np.nan
             return self._data.assign(
                 elevation_difference=self.compute_elevation_difference(),
-                sagging_parameter=self.sagging_parameter,
+                sagging_parameter=sagging_parameter,
                 sagging_temperature=self.sagging_temperature,
             )
 

--- a/test/api/test_frames.py
+++ b/test/api/test_frames.py
@@ -246,3 +246,34 @@ def test_frame__sagtension_use(section_dataframe_with_cable_weather) -> None:
         section_dataframe_with_cable_weather.state.T_h_after_change.shape
         == (4,)
     )
+
+
+def test_frame__update_paramater_wind(
+    section_dataframe_with_cable_weather,
+) -> None:
+    """Test that the sag tension is calculated correctly."""
+    wa = WeatherArray(
+        pd.DataFrame(
+            {
+                "ice_thickness": [1, 2.1, 0.0, np.nan],
+                "wind_pressure": [240.12, 0.0, 12.0, np.nan],
+            }
+        )
+    )
+    x = np.linspace(-200, 200, 20)
+    section_dataframe_with_cable_weather.state.change(100, wa)
+    z_span_after_state_change = section_dataframe_with_cable_weather.span.z(x)
+
+    expected_span = CatenarySpan(
+        **section_dataframe_with_cable_weather.data_container.__dict__
+    )
+    expected_span.sagging_parameter = (
+        section_dataframe_with_cable_weather.state.p_after_change
+    )
+    expected_z = expected_span.z(x)
+
+    np.testing.assert_allclose(
+        section_dataframe_with_cable_weather.span.sagging_parameter,
+        expected_span.sagging_parameter,
+    )
+    np.testing.assert_allclose(z_span_after_state_change, expected_z)

--- a/test/core/models/cable/test_span.py
+++ b/test/core/models/cable/test_span.py
@@ -13,9 +13,7 @@ from mechaphlowers.core.models.cable.span import (
 from mechaphlowers.entities.data_container import DataContainer
 
 
-def test_catenary_span_model__no_error_lengths(
-    default_data_container_one_span,
-) -> None:
+def test_catenary_span_model__no_error_lengths() -> None:
     a = np.array([501.3, 499.0])  # test here int and float
     b = np.array([0.0, -5.0])
     p = np.array([2_112.2, 2_112.0])

--- a/test/entities/test_arrays.py
+++ b/test/entities/test_arrays.py
@@ -220,7 +220,7 @@ def test_section_array__data(section_array_input_data: dict) -> None:
             "insulator_length": [0, 4, 3.2, 0],
             "span_length": [1, 500.2, 500.05, np.nan],
             "elevation_difference": [-1.2, -4.32, 3.32, np.nan],
-            "sagging_parameter": [2_000] * 4,
+            "sagging_parameter": [2_000.0, 2_000.0, 2_000.0, np.nan],
             "sagging_temperature": [15] * 4,
         },
     )


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**

Fixes #217 

Solves the issue by updating the sagging parameter in Span class.
This new sagging parameter is the result of change state solver 

Also update input data so that sagging_parameter has a np.nan at its end:

```python
np.array([2000, 2000, 2000, np.nan])
```
 instead of 

```python
np.array([2000, 2000, 2000, 2000])
```
