### PR TITLE
Rename T_max to T

### DIFF
--- a/docs/user_guide/ug_cable_model.md
+++ b/docs/user_guide/ug_cable_model.md
@@ -92,14 +92,14 @@ $$
     T_v(x) = T_h \cdot \sinh \left( \frac{x}{p} \right)
 $$
 
-Then, the maximal tension $T_{max}$, function of $x$, is a combination of these two components:
+Then, the norm of the tension $T$, function of $x$, is a combination of these two components:
 
 $$
-    T_{max}(x) = \sqrt{T_h^2 + T_v(x)^2}
+    T(x) = \sqrt{T_h^2 + T_v(x)^2}
 $$
 
 $$
-    T_{max}(x) = T_h \cdot \cosh⁡ \left( \frac{x}{p} \right)
+    T(x) = T_h \cdot \cosh⁡ \left( \frac{x}{p} \right)
 $$
 
 To understand the tension distribution along the cable, we calculate the overall mean tension.  
@@ -107,13 +107,13 @@ In order to do that, we can separate the cable in two halves, at $x=0$, the lowe
 Then, we can calculate ${T_{mean}}_M$ and ${T_{mean}}_N$, the mean tensions on the left and right parts of the cable respectively. They are given by the following formulas: 
 
 $$
-{T_{mean}}_M = \frac{-x_M \cdot T_h + L_M \cdot {T_{max}}_M}{2 \cdot L_M}
+{T_{mean}}_M = \frac{-x_M \cdot T_h + L_M \cdot T(x_M)}{2 \cdot L_M}
 $$
 
 and
 
 $$
-{T_{mean}}_N = \frac{x_N \cdot T_h + L_N \cdot {T_{max}}_N}{2 \cdot L_N}
+{T_{mean}}_N = \frac{x_N \cdot T_h + L_N \cdot T(x_N)}{2 \cdot L_N}
 $$
 
 where $x_M, x_N$ are the horizontal positions at $M$ and $N$, $T_h$ is the constant horizontal tension,

--- a/src/mechaphlowers/core/models/cable/span.py
+++ b/src/mechaphlowers/core/models/cable/span.py
@@ -153,8 +153,7 @@ class Span(ABC):
         """
 
     @abstractmethod
-    # Rename this method? This method computes the norm, not necessarily the max. This is only the max for x_m and x_n
-    def T_max(self, x_one_per_span: np.ndarray) -> np.ndarray:
+    def T(self, x_one_per_span: np.ndarray) -> np.ndarray:
         """Norm of the tension on the cable.
         Same as T_v, x_one_per_span must of same length as the number of spans.
 
@@ -294,11 +293,11 @@ class CatenarySpan(Span):
         p = self.sagging_parameter
         return self.compute_T_v(x_one_per_span, p, T_h)
 
-    def T_max(self, x_one_per_span) -> np.ndarray:
+    def T(self, x_one_per_span) -> np.ndarray:
         # an array of abscissa of the same length as the number of spans is expected
         T_h = self.T_h()
         p = self.sagging_parameter
-        return self.compute_T_max(x_one_per_span, p, T_h)
+        return self.compute_T(x_one_per_span, p, T_h)
 
     def T_mean_m(self) -> np.ndarray:
         a = self.span_length
@@ -380,7 +379,7 @@ class CatenarySpan(Span):
         return T_h * np.sinh(x_one_per_span / p)
 
     @staticmethod
-    def compute_T_max(
+    def compute_T(
         x_one_per_span: np.ndarray,
         p: np.ndarray,
         T_h: np.ndarray,
@@ -397,8 +396,8 @@ class CatenarySpan(Span):
     ) -> np.ndarray:
         x_m = CatenarySpan.compute_x_m(a, b, p)
         L_m = CatenarySpan.compute_L_m(a, b, p)
-        T_max_m = CatenarySpan.compute_T_max(x_m, p, T_h)
-        return (-x_m * T_h + L_m * T_max_m) / (2 * L_m)
+        T_x_m = CatenarySpan.compute_T(x_m, p, T_h)
+        return (-x_m * T_h + L_m * T_x_m) / (2 * L_m)
 
     @staticmethod
     def compute_T_mean_n(
@@ -410,8 +409,8 @@ class CatenarySpan(Span):
         # Be careful: p and T_h are linked so the input values must be consistent
         x_n = CatenarySpan.compute_x_n(a, b, p)
         L_n = CatenarySpan.compute_L_n(a, b, p)
-        T_max_n = CatenarySpan.compute_T_max(x_n, p, T_h)
-        return (x_n * T_h + L_n * T_max_n) / (2 * L_n)
+        T_x_n = CatenarySpan.compute_T(x_n, p, T_h)
+        return (x_n * T_h + L_n * T_x_n) / (2 * L_n)
 
     @staticmethod
     def compute_T_mean(

--- a/test/core/models/cable/test_span.py
+++ b/test/core/models/cable/test_span.py
@@ -46,7 +46,7 @@ def test_catenary_span_model__no_errors_tensions() -> None:
 
     span_model.T_h()
     span_model.T_v(x)
-    span_model.T_max(x)
+    span_model.T(x)
     span_model.T_mean_m()
     span_model.T_mean_n()
     span_model.T_mean()
@@ -127,7 +127,7 @@ def test_catenary_span_model__tensions__wrong_dimension_array() -> None:
     with pytest.raises(ValueError):
         span_model.T_v(x)
     with pytest.raises(ValueError):
-        span_model.T_max(x)
+        span_model.T(x)
 
 
 def test_catenary_span_model__tensions__no_elevation_difference() -> None:
@@ -185,7 +185,7 @@ def test_catenary_span_model__data_container(
     span_model.L_n()
     span_model.T_h()
     span_model.T_v(x)
-    span_model.T_max(x)
+    span_model.T(x)
     span_model.T_mean_m()
     span_model.T_mean_n()
     span_model.T_mean()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
Renaming the method `T_max()` to `T()` in `Span`

This function is actually the norm of the tension vector, so the "max" is irrelevent (only relevent when applied to the extrema)



