### PR TITLE
Catalog: separator option and validate rows

### DIFF
--- a/src/mechaphlowers/data/catalog/catalog.py
+++ b/src/mechaphlowers/data/catalog/catalog.py
@@ -222,10 +222,13 @@ class Catalog:
         return element_array
 
     def check_wrong_rows(self, clean_catalog: bool = True) -> Set:
-        """Check if rows are invalid when running get_as_object(), and eventually remove them.
+        """Check if rows are causes pandera SchemaErrors when running get_as_object(), and eventually remove them.
 
         Args:
             clean_catalog (bool): If True, removes invalid rows from the catalog. Defaults to True.
+
+        Returns:
+            Set: Set of indices of rows that are invalid according to the pandera schema.
         """
         wrong_rows = []
         try:
@@ -236,13 +239,11 @@ class Catalog:
             if clean_catalog:
                 self._data.drop(wrong_rows, inplace=True)
                 warnings.warn(
-                    f"The following rows have incorrect data, and are removed from dataframe:"
-                    f" {wrong_rows}"
+                    f"The following rows have incorrect data, and are removed from dataframe: {wrong_rows}"
                 )
             else:
                 warnings.warn(
-                    f"The following rows have incorrect data, but are NOT removed from dataframe:"
-                    f" {wrong_rows}"
+                    f"The following rows have incorrect data, but are NOT removed from dataframe: {wrong_rows}"
                 )
         return set(wrong_rows)
 

--- a/test/benchmark/test_benchmarks.py
+++ b/test/benchmark/test_benchmarks.py
@@ -44,17 +44,6 @@ except Exception as e:
 cable_list = cable_bench.keys()
 
 
-# TODO: remove this test
-def test_import_csv():
-    cable_catalog = build_catalog_from_yaml(
-        "rte_cable_database.yaml",
-        user_filepath=EXTERNAL_DATA_DIR,
-        separator=";",
-        decimal=",",
-    )
-    cable_catalog.check_wrong_rows()
-
-
 @pytest.fixture(scope="session")
 def benchmark_report():
     """Fixture to collect and report functional benchmark results."""

--- a/test/data/catalog/test_catalog.py
+++ b/test/data/catalog/test_catalog.py
@@ -495,3 +495,18 @@ def test_catalog_correct_array(cable_array_AM600) -> None:
         check_like=True,
         atol=1e-07,
     )
+
+
+def test_catalog_check_wrong_rows() -> None:
+    catalog_wrong_data = build_catalog_from_yaml("sample_cable_database.yaml")
+    catalog_wrong_data._data.at["ASTER600", "a0"] = None
+    catalog_wrong_data._data.at["ASTER600", "a1"] = None
+
+    with pytest.warns(UserWarning):
+        wrong_rows = catalog_wrong_data.check_wrong_rows(clean_catalog=False)
+    assert wrong_rows == {"ASTER600"}
+    assert "ASTER600" in catalog_wrong_data._data.index
+
+    with pytest.warns(UserWarning):
+        catalog_wrong_data.check_wrong_rows(clean_catalog=True)
+    assert "ASTER600" not in catalog_wrong_data._data.index


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
Fixes #334 



**What kind of change does this PR introduce?**
This PR fixes a bug when adding new catalogs manually for benchmark tests.
The bug mainly comes from the input files that was incorrect/has inconsistencies.
In order to avoid future errors, some features were added: 


**What is the new behavior (if this is a feature change)?**
* Adds  the option to change separator and decimal symbol when loading the csv file
* Checks if rows validates the pandera schema of the target objecy (CableArray for example) and gives the option to remove the incorrects rows

