### PR TITLE
Bugfix: azimuth does not take first angle

### DIFF
--- a/docs/user_guide/ug_balance_engine.md
+++ b/docs/user_guide/ug_balance_engine.md
@@ -81,7 +81,7 @@ Solves the insulator chain positions under new weather conditions and/or a new t
 | `wind_pressure` | `0.0` | Pa |
 | `ice_thickness` | `0.0` | m |
 | `new_temperature` | `15.0` | °C |
-| `wind_sense` | `"anticlockwise"` | — |
+| `wind_direction` | `"anticlockwise"` | — |
 
 ```python
 engine.solve_adjustment()
@@ -90,7 +90,7 @@ engine.solve_change_state(
     wind_pressure=200.0,      # Pa
     ice_thickness=0.01,       # m
     new_temperature=0.0,      # °C
-    wind_sense="anticlockwise",
+    wind_direction="anticlockwise",
 )
 
 # Results

--- a/docs/user_guide/ug_input.md
+++ b/docs/user_guide/ug_input.md
@@ -175,7 +175,7 @@ The following example shows how to add a wind load on the cable.
 
 !!! Wind direction convention
 
-    Another attention point is that the wind load can be negative, which means that the wind is blowing in the opposite direction of the line. The sign convention is parameterized by wind_sense ("clockwise" or "anticlockwise").  
+    Another attention point is that the wind load can be negative, which means that the wind is blowing in the opposite direction of the line. The sign convention is parameterized by wind_direction ("clockwise" or "anticlockwise").  
     If "clockwise": towards user (right), if "anticlockwise": away from user (left). Default to "anticlockwise".
 
 

--- a/docs/user_guide/ug_section_study.md
+++ b/docs/user_guide/ug_section_study.md
@@ -92,7 +92,7 @@ study.solve_change_state(
     wind_pressure=200,       # Pa
     ice_thickness=0.01,      # m
     new_temperature=-10,     # °C
-    wind_sense="anticlockwise",
+    wind_direction="anticlockwise",
 )
 ```
 

--- a/src/mechaphlowers/api/section_study.py
+++ b/src/mechaphlowers/api/section_study.py
@@ -153,7 +153,9 @@ class SectionStudy:
         wind_pressure: np.ndarray | float | None = None,
         ice_thickness: np.ndarray | float | None = None,
         new_temperature: np.ndarray | float | None = None,
-        wind_sense: Literal["clockwise", "anticlockwise"] = "anticlockwise",
+        wind_direction: Literal[
+            "clockwise", "anticlockwise"
+        ] = "anticlockwise",
     ) -> None:
         """Run [`BalanceEngine.solve_change_state`][mechaphlowers.core.models.balance.engine.BalanceEngine.solve_change_state] with automatic rollback.
 
@@ -169,7 +171,7 @@ class SectionStudy:
             wind_pressure (np.ndarray | float | None): Wind pressure in Pa. Defaults to None.
             ice_thickness (np.ndarray | float | None): Ice thickness in m. Defaults to None.
             new_temperature (np.ndarray | float | None): New temperature in °C. Defaults to None.
-            wind_sense (Literal["clockwise", "anticlockwise"]): Direction of the wind. Defaults to "anticlockwise".
+            wind_direction (Literal["clockwise", "anticlockwise"]): Direction of the wind. Defaults to "anticlockwise".
 
         Raises:
             SolverError: If the solver fails to converge.
@@ -205,7 +207,7 @@ class SectionStudy:
                 wind_pressure=wind_pressure,
                 ice_thickness=ice_thickness,
                 new_temperature=new_temperature,
-                wind_sense=wind_sense,
+                wind_direction=wind_direction,
             )
         except SolverError:
             logger.error(

--- a/src/mechaphlowers/core/models/balance/engine.py
+++ b/src/mechaphlowers/core/models/balance/engine.py
@@ -376,7 +376,9 @@ class BalanceEngine(Notifier):
         wind_pressure: np.ndarray | float | None = None,
         ice_thickness: np.ndarray | float | None = None,
         new_temperature: np.ndarray | float | None = None,
-        wind_sense: Literal["clockwise", "anticlockwise"] = "anticlockwise",
+        wind_direction: Literal[
+            "clockwise", "anticlockwise"
+        ] = "anticlockwise",
     ) -> None:
         """Solve the chain positions, for a case of change of state.
         Updates weather conditions and/or sagging temperature if provided.
@@ -386,7 +388,7 @@ class BalanceEngine(Notifier):
             wind_pressure (np.ndarray | float | None): Wind pressure in Pa. Default to None
             ice_thickness (np.ndarray | float | None): Ice thickness in m. Default to None
             new_temperature (np.ndarray | float | None): New temperature in °C. Default to None
-            wind_sense (Literal["clockwise", "anticlockwise"]): Direction of the wind: if "clockwise": towards user (right), if "anticlockwise": away from user (left). Default to "anticlockwise".
+            wind_direction (Literal["clockwise", "anticlockwise"]): Direction of the wind: if "clockwise": towards user (right), if "anticlockwise": away from user (left). Default to "anticlockwise".
 
         After running this method, many attributes are updated.
         Most interesting ones are `L_ref`, `parameter` in Span, and `dxdydz` in Nodes.
@@ -398,7 +400,7 @@ class BalanceEngine(Notifier):
         """
         logger.debug("Starting change state.")
         logger.debug(
-            f"Parameters received: \nwind_pressure {str(wind_pressure)}\nice_thickness {str(ice_thickness)}\nnew_temperature {str(new_temperature)}\nwind_sense {str(wind_sense)}"
+            f"Parameters received: \nwind_pressure {str(wind_pressure)}\nice_thickness {str(ice_thickness)}\nnew_temperature {str(new_temperature)}\nwind_direction {str(wind_direction)}"
         )
 
         span_shape = self.section_array.data.span_length.shape
@@ -418,12 +420,12 @@ class BalanceEngine(Notifier):
 
             return input_value
 
-        if wind_sense not in ["clockwise", "anticlockwise"]:
+        if wind_direction not in ["clockwise", "anticlockwise"]:
             raise ValueError(
-                f"wind_sense should be 'clockwise' or 'anticlockwise', received {wind_sense}"
+                f"wind_direction should be 'clockwise' or 'anticlockwise', received {wind_direction}"
             )
         validated_wind = validate_input(wind_pressure, "wind_pressure")
-        if wind_sense == "clockwise":
+        if wind_direction == "clockwise":
             validated_wind = -validated_wind
 
         self.balance_model.cable_loads.wind_pressure = validated_wind

--- a/src/mechaphlowers/entities/arrays.py
+++ b/src/mechaphlowers/entities/arrays.py
@@ -384,21 +384,35 @@ class SectionArray(ElementArray):
         latitude_0: float,
         longitude_0: float,
         azimuth_0: float,
+        azimuth_sense: Literal["clockwise", "anticlockwise"] = "anticlockwise",
     ) -> None:
         """Set the starting GPS point and azimuth for coordinate computation.
 
         Args:
             latitude_0 (float): Latitude of the first support in decimal degrees.
             longitude_0 (float): Longitude of the first support in decimal degrees.
-            azimuth_0 (float): Azimuth of the first span in degrees, anti-clockwise. 0 means North, 90 means West.
+            azimuth_0 (float): Azimuth of the first span in degrees, anti-clockwise by default. 0 means North, 90 means West.
+            azimuth_sense (Literal["clockwise", "anticlockwise"]): default to "anticlockwise"
         """
-        self.geolocator.set_starting_gps(latitude_0, longitude_0, azimuth_0)
+        if azimuth_sense == "clockwise":
+            self.geolocator.set_starting_gps(
+                latitude_0, longitude_0, -azimuth_0
+            )
+        elif azimuth_sense == "anticlockwise":
+            self.geolocator.set_starting_gps(
+                latitude_0, longitude_0, azimuth_0
+            )
+        else:
+            raise ValueError(
+                f"azimuth_sense should be 'clockwise' or 'anticlockwise', received {azimuth_sense}"
+            )
 
     def set_starting_lambert93(
         self,
         easting: float,
         northing: float,
         azimuth_0: float,
+        azimuth_sense: Literal["clockwise", "anticlockwise"] = "anticlockwise",
     ) -> None:
         """Set the starting point from Lambert 93 coordinates and azimuth.
 
@@ -407,9 +421,25 @@ class SectionArray(ElementArray):
             northing (float): Lambert 93 northing coordinate in meters.
             azimuth_0 (float): Azimuth of the first span in degrees, anti-clockwise. 0 means North, 90 means West.
         """
-        self.geolocator.set_starting_lambert93(easting, northing, azimuth_0)
 
-    def get_azimuth(self, unit: str = "deg") -> np.ndarray:
+        if azimuth_sense == "clockwise":
+            self.geolocator.set_starting_lambert93(
+                easting, northing, -azimuth_0
+            )
+        elif azimuth_sense == "anticlockwise":
+            self.geolocator.set_starting_lambert93(
+                easting, northing, azimuth_0
+            )
+        else:
+            raise ValueError(
+                f"azimuth_sense should be 'clockwise' or 'anticlockwise', received {azimuth_sense}"
+            )
+
+    def get_azimuth(
+        self,
+        unit: str = "deg",
+        output_sense: Literal["clockwise", "anticlockwise"] = "anticlockwise",
+    ) -> np.ndarray:
         """Compute azimuth angle (or bearing) of the section.
         0 is toward North. 90 degrees is toward West. (anti-clockwise sense)
 
@@ -423,12 +453,21 @@ class SectionArray(ElementArray):
         line_angles_degrees = (
             Q_(self.data["line_angle"].to_numpy(), "rad").to("deg").m
         )
-        return get_azimuth_from_line_angles(
+        azimuth_anticlockwise = get_azimuth_from_line_angles(
             line_angles_degrees,
             self.geolocator._azimuth_0,  # type: ignore[arg-type]
             input_unit="deg",
             output_unit=unit,
         )
+
+        if output_sense == "anticlockwise":
+            return azimuth_anticlockwise
+        elif output_sense == "clockwise":
+            return -azimuth_anticlockwise
+        else:
+            raise ValueError(
+                f"output_sense should be 'clockwise' or 'anticlockwise', received {output_sense}"
+            )
 
     def get_gps(self) -> tuple[np.ndarray, np.ndarray]:
         """Compute GPS coordinates for all pylons.

--- a/src/mechaphlowers/entities/arrays.py
+++ b/src/mechaphlowers/entities/arrays.py
@@ -392,7 +392,7 @@ class SectionArray(ElementArray):
             latitude_0 (float): Latitude of the first support in decimal degrees.
             longitude_0 (float): Longitude of the first support in decimal degrees.
             azimuth_0 (float): Azimuth of the first span in degrees, anti-clockwise by default. 0 means North, 90 means West.
-            azimuth_sense (Literal["clockwise", "anticlockwise"]): default to "anticlockwise"
+            azimuth_sense (Literal["clockwise", "anticlockwise"]): Angle sense for azimuth_0. If set to "clockwise": 90 means East, -90 means West. Default to "anticlockwise"
         """
         if azimuth_sense == "clockwise":
             self.geolocator.set_starting_gps(
@@ -420,6 +420,7 @@ class SectionArray(ElementArray):
             easting (float): Lambert 93 easting coordinate in meters.
             northing (float): Lambert 93 northing coordinate in meters.
             azimuth_0 (float): Azimuth of the first span in degrees, anti-clockwise. 0 means North, 90 means West.
+            azimuth_sense (Literal["clockwise", "anticlockwise"]): Angle sense for azimuth_0. If set to "clockwise": 90 means East, -90 means West. Default to "anticlockwise"
         """
 
         if azimuth_sense == "clockwise":
@@ -441,10 +442,11 @@ class SectionArray(ElementArray):
         output_sense: Literal["clockwise", "anticlockwise"] = "anticlockwise",
     ) -> np.ndarray:
         """Compute azimuth angle (or bearing) of the section.
-        0 is toward North. 90 degrees is toward West. (anti-clockwise sense)
+        By default, using anti-clockwise sense : 0 is toward North. 90 degrees is toward West.
 
         Args:
             unit (str, optional): Output unit. Defaults to "deg".
+            output_sense (Literal["clockwise", "anticlockwise"]): Angle sense for output. If set to "clockwise": 90 means East, -90 means West. Default to "anticlockwise"
 
         Returns:
             np.ndarray: array of the azimuth of each span.

--- a/src/mechaphlowers/entities/arrays.py
+++ b/src/mechaphlowers/entities/arrays.py
@@ -21,7 +21,10 @@ from typing_extensions import Literal, Self, Type
 from mechaphlowers.config import options
 from mechaphlowers.data.units import Q_, convert_mass_to_weight
 from mechaphlowers.entities.errors import DataWarning
-from mechaphlowers.entities.geography import GeoLocator
+from mechaphlowers.entities.geography import (
+    GeoLocator,
+    get_azimuth_from_line_angles,
+)
 
 if TYPE_CHECKING:
     from mechaphlowers.core.models.cable.cable_strength import ITensileStrength
@@ -420,10 +423,12 @@ class SectionArray(ElementArray):
         line_angles_degrees = (
             Q_(self.data["line_angle"].to_numpy(), "rad").to("deg").m
         )
-        azimuth_deg = (
-            np.cumsum(line_angles_degrees) + self.geolocator._azimuth_0
+        return get_azimuth_from_line_angles(
+            line_angles_degrees,
+            self.geolocator._azimuth_0,  # type: ignore[arg-type]
+            input_unit="deg",
+            output_unit=unit,
         )
-        return Q_(azimuth_deg, "deg").to(unit).m
 
     def get_gps(self) -> tuple[np.ndarray, np.ndarray]:
         """Compute GPS coordinates for all pylons.

--- a/src/mechaphlowers/entities/arrays.py
+++ b/src/mechaphlowers/entities/arrays.py
@@ -193,7 +193,7 @@ class SectionArray(ElementArray):
         self.bundle_number = bundle_number
         self.input_units = options.input_units.section_array.copy()
         self.correct_insulator_length()
-        self._angles_direction: Literal["clockwise", "anticlockwise"] = (
+        self._angle_direction: Literal["clockwise", "anticlockwise"] = (
             "anticlockwise"
         )
         self.geolocator: GeoLocator = GeoLocator()
@@ -226,24 +226,24 @@ class SectionArray(ElementArray):
         )
 
     @property
-    def angles_direction(self) -> Literal["clockwise", "anticlockwise"]:
+    def angle_direction(self) -> Literal["clockwise", "anticlockwise"]:
         """Affects line_angle, crossarm_length sign
 
         If "anticlockwise", line_angle is anticlockwise and crossarm_length is away from user (left).
         If "clockwise", line_angle is clockwise and crossarm_length is towards user (right).
 
         Defaults to "anticlockwise"."""
-        return self._angles_direction
+        return self._angle_direction
 
-    @angles_direction.setter
-    def angles_direction(
+    @angle_direction.setter
+    def angle_direction(
         self, value: Literal["clockwise", "anticlockwise"]
     ) -> None:
         if value not in ["clockwise", "anticlockwise"]:
             raise ValueError(
-                f"angles_direction should be 'clockwise' or 'anticlockwise', received {value}"
+                f"angle_direction should be 'clockwise' or 'anticlockwise', received {value}"
             )
-        self._angles_direction = value
+        self._angle_direction = value
 
     @property
     def sagging_parameter(self):
@@ -338,7 +338,7 @@ class SectionArray(ElementArray):
     def _adjust_angle_direction(
         self, data_output: pd.DataFrame
     ) -> pd.DataFrame:
-        if self.angles_direction == "clockwise":
+        if self.angle_direction == "clockwise":
             # use data_output instead of self._data to keep eventual unit conversion
             data_output["line_angle"] = -data_output["line_angle"]
             data_output["crossarm_length"] = -data_output["crossarm_length"]

--- a/src/mechaphlowers/entities/arrays.py
+++ b/src/mechaphlowers/entities/arrays.py
@@ -193,7 +193,7 @@ class SectionArray(ElementArray):
         self.bundle_number = bundle_number
         self.input_units = options.input_units.section_array.copy()
         self.correct_insulator_length()
-        self._angles_sense: Literal["clockwise", "anticlockwise"] = (
+        self._angles_direction: Literal["clockwise", "anticlockwise"] = (
             "anticlockwise"
         )
         self.geolocator: GeoLocator = GeoLocator()
@@ -226,24 +226,24 @@ class SectionArray(ElementArray):
         )
 
     @property
-    def angles_sense(self) -> Literal["clockwise", "anticlockwise"]:
+    def angles_direction(self) -> Literal["clockwise", "anticlockwise"]:
         """Affects line_angle, crossarm_length sign
 
         If "anticlockwise", line_angle is anticlockwise and crossarm_length is away from user (left).
         If "clockwise", line_angle is clockwise and crossarm_length is towards user (right).
 
         Defaults to "anticlockwise"."""
-        return self._angles_sense
+        return self._angles_direction
 
-    @angles_sense.setter
-    def angles_sense(
+    @angles_direction.setter
+    def angles_direction(
         self, value: Literal["clockwise", "anticlockwise"]
     ) -> None:
         if value not in ["clockwise", "anticlockwise"]:
             raise ValueError(
-                f"angles_sense should be 'clockwise' or 'anticlockwise', received {value}"
+                f"angles_direction should be 'clockwise' or 'anticlockwise', received {value}"
             )
-        self._angles_sense = value
+        self._angles_direction = value
 
     @property
     def sagging_parameter(self):
@@ -312,7 +312,7 @@ class SectionArray(ElementArray):
         }
         self.create_column_weight(data_output, mass_weight_conversion)
         self.validate_ground_altitude(data_output)
-        data_output = self._adjust_angle_sense(data_output)
+        data_output = self._adjust_angle_direction(data_output)
         return data_output.assign(
             elevation_difference=self.compute_elevation_difference(),
             bundle_number=self.bundle_number,
@@ -335,8 +335,10 @@ class SectionArray(ElementArray):
                     df_output[column_mass].to_numpy()
                 )
 
-    def _adjust_angle_sense(self, data_output: pd.DataFrame) -> pd.DataFrame:
-        if self.angles_sense == "clockwise":
+    def _adjust_angle_direction(
+        self, data_output: pd.DataFrame
+    ) -> pd.DataFrame:
+        if self.angles_direction == "clockwise":
             # use data_output instead of self._data to keep eventual unit conversion
             data_output["line_angle"] = -data_output["line_angle"]
             data_output["crossarm_length"] = -data_output["crossarm_length"]
@@ -384,7 +386,9 @@ class SectionArray(ElementArray):
         latitude_0: float,
         longitude_0: float,
         azimuth_0: float,
-        azimuth_sense: Literal["clockwise", "anticlockwise"] = "anticlockwise",
+        azimuth_direction: Literal[
+            "clockwise", "anticlockwise"
+        ] = "anticlockwise",
     ) -> None:
         """Set the starting GPS point and azimuth for coordinate computation.
 
@@ -392,19 +396,19 @@ class SectionArray(ElementArray):
             latitude_0 (float): Latitude of the first support in decimal degrees.
             longitude_0 (float): Longitude of the first support in decimal degrees.
             azimuth_0 (float): Azimuth of the first span in degrees, anti-clockwise by default. 0 means North, 90 means West.
-            azimuth_sense (Literal["clockwise", "anticlockwise"]): Angle sense for azimuth_0. If set to "clockwise": 90 means East, -90 means West. Default to "anticlockwise"
+            azimuth_direction (Literal["clockwise", "anticlockwise"]): Angle sense for azimuth_0. If set to "clockwise": 90 means East, -90 means West. Default to "anticlockwise"
         """
-        if azimuth_sense == "clockwise":
+        if azimuth_direction == "clockwise":
             self.geolocator.set_starting_gps(
                 latitude_0, longitude_0, -azimuth_0
             )
-        elif azimuth_sense == "anticlockwise":
+        elif azimuth_direction == "anticlockwise":
             self.geolocator.set_starting_gps(
                 latitude_0, longitude_0, azimuth_0
             )
         else:
             raise ValueError(
-                f"azimuth_sense should be 'clockwise' or 'anticlockwise', received {azimuth_sense}"
+                f"azimuth_direction should be 'clockwise' or 'anticlockwise', received {azimuth_direction}"
             )
 
     def set_starting_lambert93(
@@ -412,7 +416,9 @@ class SectionArray(ElementArray):
         easting: float,
         northing: float,
         azimuth_0: float,
-        azimuth_sense: Literal["clockwise", "anticlockwise"] = "anticlockwise",
+        azimuth_direction: Literal[
+            "clockwise", "anticlockwise"
+        ] = "anticlockwise",
     ) -> None:
         """Set the starting point from Lambert 93 coordinates and azimuth.
 
@@ -420,33 +426,35 @@ class SectionArray(ElementArray):
             easting (float): Lambert 93 easting coordinate in meters.
             northing (float): Lambert 93 northing coordinate in meters.
             azimuth_0 (float): Azimuth of the first span in degrees, anti-clockwise. 0 means North, 90 means West.
-            azimuth_sense (Literal["clockwise", "anticlockwise"]): Angle sense for azimuth_0. If set to "clockwise": 90 means East, -90 means West. Default to "anticlockwise"
+            azimuth_direction (Literal["clockwise", "anticlockwise"]): Angle sense for azimuth_0. If set to "clockwise": 90 means East, -90 means West. Default to "anticlockwise"
         """
 
-        if azimuth_sense == "clockwise":
+        if azimuth_direction == "clockwise":
             self.geolocator.set_starting_lambert93(
                 easting, northing, -azimuth_0
             )
-        elif azimuth_sense == "anticlockwise":
+        elif azimuth_direction == "anticlockwise":
             self.geolocator.set_starting_lambert93(
                 easting, northing, azimuth_0
             )
         else:
             raise ValueError(
-                f"azimuth_sense should be 'clockwise' or 'anticlockwise', received {azimuth_sense}"
+                f"azimuth_direction should be 'clockwise' or 'anticlockwise', received {azimuth_direction}"
             )
 
     def get_azimuth(
         self,
         unit: str = "deg",
-        output_sense: Literal["clockwise", "anticlockwise"] = "anticlockwise",
+        output_direction: Literal[
+            "clockwise", "anticlockwise"
+        ] = "anticlockwise",
     ) -> np.ndarray:
         """Compute azimuth angle (or bearing) of the section.
         By default, using anti-clockwise sense : 0 is toward North. 90 degrees is toward West.
 
         Args:
             unit (str, optional): Output unit. Defaults to "deg".
-            output_sense (Literal["clockwise", "anticlockwise"]): Angle sense for output. If set to "clockwise": 90 means East, -90 means West. Default to "anticlockwise"
+            output_direction (Literal["clockwise", "anticlockwise"]): Angle sense for output. If set to "clockwise": 90 means East, -90 means West. Default to "anticlockwise"
 
         Returns:
             np.ndarray: array of the azimuth of each span.
@@ -462,13 +470,13 @@ class SectionArray(ElementArray):
             output_unit=unit,
         )
 
-        if output_sense == "anticlockwise":
+        if output_direction == "anticlockwise":
             return azimuth_anticlockwise
-        elif output_sense == "clockwise":
+        elif output_direction == "clockwise":
             return -azimuth_anticlockwise
         else:
             raise ValueError(
-                f"output_sense should be 'clockwise' or 'anticlockwise', received {output_sense}"
+                f"output_direction should be 'clockwise' or 'anticlockwise', received {output_direction}"
             )
 
     def get_gps(self) -> tuple[np.ndarray, np.ndarray]:

--- a/src/mechaphlowers/entities/geography.py
+++ b/src/mechaphlowers/entities/geography.py
@@ -221,10 +221,13 @@ def get_azimuth_from_line_angles(
     input_unit: str = "deg",
     output_unit: str = "deg",
 ):
+    if len(line_angle) == 0:
+        return np.array([])
     # first value of line_angles is set to 0 to avoid unexpected behaviour.
     # now azimuth is truly the orientation of the first span
-    line_angle[0] = 0.0
-    azimuth = np.cumsum(line_angle) + azimuth_first
+    line_angle_copy = line_angle.copy()
+    line_angle_copy[0] = 0.0
+    azimuth = np.cumsum(line_angle_copy) + azimuth_first
     return Q_(azimuth, input_unit).to(output_unit).m
 
 

--- a/src/mechaphlowers/entities/geography.py
+++ b/src/mechaphlowers/entities/geography.py
@@ -217,17 +217,28 @@ def get_gps_from_arrays(
 
 def get_azimuth_from_line_angles(
     line_angle: np.ndarray,
-    azimuth_first: float,
+    first_span_azimuth: float,
     input_unit: str = "deg",
     output_unit: str = "deg",
-):
+) -> np.ndarray:
+    """Compute azimuth of all spans.
+
+    Args:
+        line_angle (np.ndarray): line angle array in anticlockwise direction. Array comes from SectionArray.
+        first_span_azimuth (float): azimuth of the first span. Anticlockwise: 90° towards west
+        input_unit (str, optional): unit of line_angle and line_angle. Defaults to "deg".
+        output_unit (str, optional): unit of the output. Defaults to "deg".
+
+    Returns:
+        np.ndarray: array of azimuth. Length of array is number of supports.
+    """
     if len(line_angle) == 0:
         return np.array([])
     # first value of line_angles is set to 0 to avoid unexpected behaviour.
     # now azimuth is truly the orientation of the first span
     line_angle_copy = line_angle.copy()
     line_angle_copy[0] = 0.0
-    azimuth = np.cumsum(line_angle_copy) + azimuth_first
+    azimuth = np.cumsum(line_angle_copy) + first_span_azimuth
     return Q_(azimuth, input_unit).to(output_unit).m
 
 

--- a/src/mechaphlowers/entities/geography.py
+++ b/src/mechaphlowers/entities/geography.py
@@ -197,11 +197,10 @@ def get_gps_from_arrays(
     current_lon_rad = np.radians(start_lon_deg)
     lat_array_rad = [current_lat_rad]
     lon_array_rad = [current_lon_rad]
-    # first value of line_angles is set to 0 to avoid unexpected behaviour.
-    # now azimuth is truly the orientation of the first span
-    line_angles_degrees[0] = 0.0
-    bearings_deg = np.cumsum(line_angles_degrees) + azimuth_deg
-    bearings_rad = np.radians(bearings_deg)
+
+    bearings_rad = get_azimuth_from_line_angles(
+        line_angles_degrees, azimuth_deg, input_unit="deg", output_unit="rad"
+    )
     # Deliberate choice to not take into account the last angle: refers to the angle with the next section
     for index in range(len(line_angles_degrees) - 1):
         # Build the current point using the previous one, length and angle
@@ -214,6 +213,19 @@ def get_gps_from_arrays(
         lat_array_rad.append(current_lat_rad)
         lon_array_rad.append(current_lon_rad)
     return np.degrees(lat_array_rad), np.degrees(lon_array_rad)
+
+
+def get_azimuth_from_line_angles(
+    line_angle: np.ndarray,
+    azimuth_first: float,
+    input_unit: str = "deg",
+    output_unit: str = "deg",
+):
+    # first value of line_angles is set to 0 to avoid unexpected behaviour.
+    # now azimuth is truly the orientation of the first span
+    line_angle[0] = 0.0
+    azimuth = np.cumsum(line_angle) + azimuth_first
+    return Q_(azimuth, input_unit).to(output_unit).m
 
 
 class GeoLocator:
@@ -272,7 +284,11 @@ class GeoLocator:
         return new
 
     def _check_gps_available(self) -> None:
-        if self._latitude_0 is None:
+        if (
+            self._latitude_0 is None
+            or self._longitude_0 is None
+            or self._azimuth_0 is None
+        ):
             raise GpsNoDataAvailable(
                 "Location data is not available. Call set_starting_gps() or set_starting_lambert93() first."
             )

--- a/test/core/models/balance/test_engine.py
+++ b/test/core/models/balance/test_engine.py
@@ -412,13 +412,13 @@ def test_get_data_spans_with_loads(balance_engine_simple: BalanceEngine):
         assert len(value) == 3
 
 
-def test_engine_wind_sense(balance_engine_simple: BalanceEngine):
+def test_engine_wind_direction(balance_engine_simple: BalanceEngine):
     balance_engine_simple.solve_adjustment()
 
-    # Test with wind_sense "clockwise"
+    # Test with wind_direction "clockwise"
     balance_engine_simple.solve_change_state(
         wind_pressure=200,
-        wind_sense="clockwise",
+        wind_direction="clockwise",
     )
     displacement_clockwise = (
         balance_engine_simple.balance_model.chain_displacement()
@@ -429,10 +429,10 @@ def test_engine_wind_sense(balance_engine_simple: BalanceEngine):
         np.array([-200.0, -200.0, -200.0, -200.0]),
     )
 
-    # Test with wind_sense "anticlockwise"
+    # Test with wind_direction "anticlockwise"
     balance_engine_simple.solve_change_state(
         wind_pressure=-200,
-        wind_sense="anticlockwise",
+        wind_direction="anticlockwise",
     )
     np.testing.assert_array_equal(
         balance_engine_simple.balance_model.cable_loads.wind_pressure,

--- a/test/entities/test_section_array.py
+++ b/test/entities/test_section_array.py
@@ -560,7 +560,7 @@ def test_section_array_to_gps():
                 "conductor_attachment_altitude": np.array([20, 5, 10, 0, 0]),
                 "crossarm_length": np.array([10, 12.1, 10, 10.1, 5]),
                 "line_angle": np.array([90, 90, 90, 90, 90]),
-                "insulator_length": np.array([0, 4, 3.2, 0, 0]),
+                "insulator_length": np.array([0.01, 0.01, 0.01, 0.01, 0.01]),
                 "span_length": np.array([500, 500, 500.0, 500.0, np.nan]),
                 "insulator_mass": np.array(
                     [1000.0, 500.0, 500.0, 500.0, 1000.0]
@@ -628,7 +628,7 @@ def test_section_array_get_lambert93():
                 "conductor_attachment_altitude": np.array([20, 5, 10, 0, 0]),
                 "crossarm_length": np.array([10, 12.1, 10, 10.1, 5]),
                 "line_angle": np.array([90, 90, 90, 90, 90]),
-                "insulator_length": np.array([0, 4, 3.2, 0, 0]),
+                "insulator_length": np.array([0.01, 0.01, 0.01, 0.01, 0.01]),
                 "span_length": np.array([500, 500, 500.0, 500.0, np.nan]),
                 "insulator_mass": np.array(
                     [1000.0, 500.0, 500.0, 500.0, 1000.0]
@@ -662,7 +662,7 @@ def test_section_array_copy_preserves_geolocator():
                 "conductor_attachment_altitude": np.array([20, 5, 10, 0, 0]),
                 "crossarm_length": np.array([10, 12.1, 10, 10.1, 5]),
                 "line_angle": np.array([90, 90, 90, 90, 90]),
-                "insulator_length": np.array([0, 4, 3.2, 0, 0]),
+                "insulator_length": np.array([0.01, 0.01, 0.01, 0.01, 0.01]),
                 "span_length": np.array([500, 500, 500.0, 500.0, np.nan]),
                 "insulator_mass": np.array(
                     [1000.0, 500.0, 500.0, 500.0, 1000.0]
@@ -693,7 +693,7 @@ def test_section_array_copy_geolocator_is_independent():
                 "conductor_attachment_altitude": np.array([20, 5, 10, 0, 0]),
                 "crossarm_length": np.array([10, 12.1, 10, 10.1, 5]),
                 "line_angle": np.array([90, 90, 90, 90, 90]),
-                "insulator_length": np.array([0, 4, 3.2, 0, 0]),
+                "insulator_length": np.array([0.01, 0.01, 0.01, 0.01, 0.01]),
                 "span_length": np.array([500, 500, 500.0, 500.0, np.nan]),
                 "insulator_mass": np.array(
                     [1000.0, 500.0, 500.0, 500.0, 1000.0]
@@ -731,7 +731,7 @@ def test_section_array_get_azimuth():
                 "conductor_attachment_altitude": np.array([20, 5, 10, 0, 0]),
                 "crossarm_length": np.array([10, 12.1, 10, 10.1, 5]),
                 "line_angle": np.array([17, 5, 10, 15, 22]),
-                "insulator_length": np.array([0, 4, 3.2, 0, 0]),
+                "insulator_length": np.array([0.01, 0.01, 0.01, 0.01, 0.01]),
                 "span_length": np.array([500, 500, 500.0, 500.0, np.nan]),
                 "insulator_mass": np.array(
                     [1000.0, 500.0, 500.0, 500.0, 1000.0]
@@ -747,6 +747,37 @@ def test_section_array_get_azimuth():
     )
     np.testing.assert_equal(
         section_array.get_azimuth(), np.array([10, 15, 25, 40, 62])
+    )
+
+
+def test_section_array_get_azimuth_clockwise():
+    section_array = SectionArray(
+        pd.DataFrame(
+            {
+                "name": np.array(["1", "2", "three", "4", "5"]),
+                "suspension": np.array([False, True, True, True, False]),
+                "conductor_attachment_altitude": np.array([20, 5, 10, 0, 0]),
+                "crossarm_length": np.array([10, 12.1, 10, 10.1, 5]),
+                "line_angle": np.array([0, 5, 10, 15, 22]),
+                "insulator_length": np.array([0.01, 0.01, 0.01, 0.01, 0.01]),
+                "span_length": np.array([500, 500, 500.0, 500.0, np.nan]),
+                "insulator_mass": np.array(
+                    [1000.0, 500.0, 500.0, 500.0, 1000.0]
+                ),
+            }
+        )
+    )
+    section_array.add_units({"line_angle": "deg"})
+    section_array.angles_sense = "clockwise"
+    section_array.set_starting_gps(
+        latitude_0=48.8566,
+        longitude_0=2.3522,
+        azimuth_0=10,
+        azimuth_sense="clockwise",
+    )
+    np.testing.assert_equal(
+        section_array.get_azimuth(output_sense="clockwise"),
+        np.array([10, 15, 25, 40, 62]),
     )
 
 

--- a/test/entities/test_section_array.py
+++ b/test/entities/test_section_array.py
@@ -768,7 +768,7 @@ def test_section_array_get_azimuth_clockwise():
         )
     )
     section_array.add_units({"line_angle": "deg"})
-    section_array.angles_direction = "clockwise"
+    section_array.angle_direction = "clockwise"
     section_array.set_starting_gps(
         latitude_0=48.8566,
         longitude_0=2.3522,
@@ -864,7 +864,7 @@ def test_section_array_angle_direction() -> None:
         sagging_temperature=15,
     )
     section_array.add_units({"line_angle": "deg"})
-    section_array.angles_direction = "clockwise"
+    section_array.angle_direction = "clockwise"
     expected_line_angle = -np.radians([10, 15, -20, 25])
     np.testing.assert_allclose(
         section_array.data.line_angle, expected_line_angle

--- a/test/entities/test_section_array.py
+++ b/test/entities/test_section_array.py
@@ -768,15 +768,15 @@ def test_section_array_get_azimuth_clockwise():
         )
     )
     section_array.add_units({"line_angle": "deg"})
-    section_array.angles_sense = "clockwise"
+    section_array.angles_direction = "clockwise"
     section_array.set_starting_gps(
         latitude_0=48.8566,
         longitude_0=2.3522,
         azimuth_0=10,
-        azimuth_sense="clockwise",
+        azimuth_direction="clockwise",
     )
     np.testing.assert_equal(
-        section_array.get_azimuth(output_sense="clockwise"),
+        section_array.get_azimuth(output_direction="clockwise"),
         np.array([10, 15, 25, 40, 62]),
     )
 
@@ -844,7 +844,7 @@ def test_section_array__data_with_counterweight(
     )
 
 
-def test_section_array_angle_sense() -> None:
+def test_section_array_angle_direction() -> None:
     section_array = SectionArray(
         pd.DataFrame(
             {
@@ -864,7 +864,7 @@ def test_section_array_angle_sense() -> None:
         sagging_temperature=15,
     )
     section_array.add_units({"line_angle": "deg"})
-    section_array.angles_sense = "clockwise"
+    section_array.angles_direction = "clockwise"
     expected_line_angle = -np.radians([10, 15, -20, 25])
     np.testing.assert_allclose(
         section_array.data.line_angle, expected_line_angle

--- a/test/entities/test_section_array.py
+++ b/test/entities/test_section_array.py
@@ -722,6 +722,34 @@ def test_section_array_copy_geolocator_is_independent():
     assert not np.allclose(lon_orig, lon_copy)
 
 
+def test_section_array_get_azimuth():
+    section_array = SectionArray(
+        pd.DataFrame(
+            {
+                "name": np.array(["1", "2", "three", "4", "5"]),
+                "suspension": np.array([False, True, True, True, False]),
+                "conductor_attachment_altitude": np.array([20, 5, 10, 0, 0]),
+                "crossarm_length": np.array([10, 12.1, 10, 10.1, 5]),
+                "line_angle": np.array([17, 5, 10, 15, 22]),
+                "insulator_length": np.array([0, 4, 3.2, 0, 0]),
+                "span_length": np.array([500, 500, 500.0, 500.0, np.nan]),
+                "insulator_mass": np.array(
+                    [1000.0, 500.0, 500.0, 500.0, 1000.0]
+                ),
+            }
+        )
+    )
+    section_array.add_units({"line_angle": "deg"})
+    section_array.set_starting_gps(
+        latitude_0=48.8566,
+        longitude_0=2.3522,
+        azimuth_0=10,
+    )
+    np.testing.assert_equal(
+        section_array.get_azimuth(), np.array([10, 15, 25, 40, 62])
+    )
+
+
 def test_equivalent_span(section_array) -> None:
     res = (
         section_array.data.span_length**3


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
Bugfix: factorize the azimuth calculation and avoid taking into account the angle of the first span



**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *breaking change* or *deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

BREAKING CHANGE!

`SectionArray.angle_sense` renamed to `SectionArray.angle_direction`

`BalanceEngine.solve_change_state()` and `SectionStudy.solve_change_state()` signature changed:
From


```python
    def solve_change_state(
        self,
        wind_pressure: np.ndarray | float | None = None,
        ice_thickness: np.ndarray | float | None = None,
        new_temperature: np.ndarray | float | None = None,
        wind_sense Literal["clockwise", "anticlockwise"] = "anticlockwise",
    ) -> None:
```

to:

```python
    def solve_change_state(
        self,
        wind_pressure: np.ndarray | float | None = None,
        ice_thickness: np.ndarray | float | None = None,
        new_temperature: np.ndarray | float | None = None,
        wind_direction: Literal["clockwise", "anticlockwise"] = "anticlockwise",
    ) -> None:
```

