### PR TITLE
Feature: Ruling span length

### DIFF
--- a/src/mechaphlowers/core/models/balance/engine.py
+++ b/src/mechaphlowers/core/models/balance/engine.py
@@ -532,6 +532,24 @@ class BalanceEngine(Notifier):
         }
         return result_dict
 
+    def get_ruling_span_length(self) -> float:
+        """Compute ruling span length:
+
+        if we consider the whole section as a single span, the length would be ruling_span_length
+
+        Used for tensions computation when unfolding the cable.
+
+        $L_{R} = \\sqrt{\\frac{\\sum(L_n ^ 4 / C_n)}{\\sum{C_n}}}$
+
+        where $L_n$ are the horizontal length of span n, and $C_n$ the chord length of span n
+
+        Returns:
+            float: span length of ruling span
+        """
+        # proto uses section_array.span_length instead of balance_model.a (called a_chain in proto)
+        chord = np.sqrt(self.balance_model.a**2 + self.balance_model.b**2)
+        return np.sqrt(np.sum(self.balance_model.a**4 / chord) / np.sum(chord))
+
     @property
     def support_number(self) -> int:
         return self.section_array.data.span_length.shape[0]

--- a/src/mechaphlowers/core/models/balance/engine.py
+++ b/src/mechaphlowers/core/models/balance/engine.py
@@ -535,7 +535,7 @@ class BalanceEngine(Notifier):
     def get_ruling_span_length(self) -> float:
         """Compute ruling span length:
 
-        if we consider the whole section as a single span, the length would be ruling_span_length
+        if we considered the whole section as a single span, the length would be ruling_span_length
 
         Used for tensions computation when unfolding the cable.
 

--- a/src/mechaphlowers/entities/arrays.py
+++ b/src/mechaphlowers/entities/arrays.py
@@ -340,7 +340,9 @@ class SectionArray(ElementArray):
         return data_output
 
     def equivalent_span(self) -> float:
-        """equivalent_span
+        """Compute equivalent span length.
+
+        Used in the default value of sagging_parameter.
 
         compute equivalent span:
            $L_{eq} = \\sqrt{\\sum(L_i ^ 3)/\\sum L_i}$

--- a/test/core/models/balance/test_engine.py
+++ b/test/core/models/balance/test_engine.py
@@ -626,3 +626,67 @@ def test_add_cable_shifting_stores_values(
     np.testing.assert_array_equal(
         balance_engine_simple.shortening_span, shortening
     )
+
+
+@pytest.mark.integration
+def test_ruling_span_length(cable_array_AM600: CableArray):
+    section_array = SectionArray(
+        pd.DataFrame(
+            {
+                "name": ["1", "2", "3", "4"],
+                "suspension": [False, True, True, False],
+                "conductor_attachment_altitude": [30, 50, 60, 65],
+                "crossarm_length": [0, 10, 10, 0],
+                "line_angle": [0, 0, 0, 0],
+                "insulator_length": [0, 3, 3, 0],
+                "span_length": [500, 300, 400, np.nan],
+                "insulator_mass": [100, 50, 50, 100],
+                "load_mass": [0, 0, 0, 0],
+                "load_position": [0, 0, 0, 0],
+            }
+        ),
+        sagging_parameter=2000,
+        sagging_temperature=15,
+    )
+    section_array.add_units({"line_angle": "grad"})
+    balance_engine = BalanceEngine(
+        cable_array=cable_array_AM600,
+        section_array=section_array,
+    )
+    balance_engine.solve_adjustment()
+    balance_engine.solve_change_state()
+    ruling_span = balance_engine.get_ruling_span_length()
+    # Value from proto. Result is close but not exactly the same due to using a_chain instead of a
+    np.testing.assert_allclose(ruling_span, 424.04, atol=0.1)
+
+
+@pytest.mark.integration
+def test_ruling_span_length_angle(cable_array_AM600: CableArray):
+    section_array = SectionArray(
+        pd.DataFrame(
+            {
+                "name": ["1", "2", "3", "4"],
+                "suspension": [False, True, True, False],
+                "conductor_attachment_altitude": [30, 50, 60, 65],
+                "crossarm_length": [0, 10, 10, 0],
+                "line_angle": [0, 20, 30, 0],
+                "insulator_length": [0, 3, 3, 0],
+                "span_length": [500, 300, 400, np.nan],
+                "insulator_mass": [100, 50, 50, 100],
+                "load_mass": [0, 0, 0, 0],
+                "load_position": [0, 0, 0, 0],
+            }
+        ),
+        sagging_parameter=2000,
+        sagging_temperature=15,
+    )
+    section_array.add_units({"line_angle": "grad"})
+    balance_engine = BalanceEngine(
+        cable_array=cable_array_AM600,
+        section_array=section_array,
+    )
+    balance_engine.solve_adjustment()
+    balance_engine.solve_change_state()
+    ruling_span = balance_engine.get_ruling_span_length()
+    # value in proto is 424.04, but our value is supposed to be the correct one
+    np.testing.assert_allclose(ruling_span, 421.74, atol=0.1)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
Add a new method in BalanceEngine for computing ruling span length
Used in stellar for pose table 
https://github.com/phlowers/phlowers-stellar-app/issues/911