### PR TITLE
Add standard uncertainty to temperature computation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "plotly<=5.24.1",
     "pyyaml==6.0.2",
     "pint==0.25",
-    "thermohl==1.6.0",
+    "thermohl==1.7.0",
     "xxhash==3.5.0",
     "pydantic==2.10.6",
 ]

--- a/src/mechaphlowers/core/models/cable/thermal.py
+++ b/src/mechaphlowers/core/models/cable/thermal.py
@@ -16,6 +16,7 @@ from thermohl import solver  # type: ignore
 from typing_extensions import Self
 
 from mechaphlowers.entities.arrays import CableArray
+from mechaphlowers.entities.errors import UncertaintyNotAvailable
 
 logger = logging.getLogger(__name__)
 
@@ -128,6 +129,21 @@ class ThermalSteadyResults(ThermalResults):
         if isinstance(data, pd.DataFrame):
             return data.copy()
         return pd.DataFrame(data)
+
+
+class SteadyIntensityResults(ThermalSteadyResults):
+    pass
+
+
+class SteadyTemperatureResults(ThermalSteadyResults):
+    @property
+    def uncertainty(self) -> np.ndarray:
+        if "uncertainty" in self.data.columns:
+            return self.data["uncertainty"].to_numpy()
+        raise UncertaintyNotAvailable(
+            "Uncertainty not available. It is only computed if you pass"
+            " 'return_uncertainty=True' to thermal_engine.steady_temperature."
+        )
 
 
 class ThermalForecastArray:
@@ -526,17 +542,17 @@ class ThermalEngine:
         self,
         intensity: np.ndarray | None = None,
         return_uncertainty: bool = False,
-    ) -> ThermalSteadyResults:
+    ) -> SteadyTemperatureResults:
         """Compute steady-state temperature results.
 
         Returns:
-            ThermalSteadyResults: An instance containing steady-state temperature data.
+            SteadyTemperatureResults: An instance containing steady-state temperature data.
         """
         logger.debug("Get steady_temperature()")
         if intensity is not None:
             self.dict_input["transit"] = intensity
             self.load()
-        return ThermalSteadyResults(
+        return SteadyTemperatureResults(
             self.thermal_model.steady_temperature(
                 return_uncertainty=return_uncertainty
             )
@@ -544,16 +560,16 @@ class ThermalEngine:
 
     def steady_intensity(
         self, target_temperature: np.ndarray | None = None
-    ) -> ThermalSteadyResults:
+    ) -> SteadyIntensityResults:
         """Compute steady-state intensity results.
 
         Returns:
-            ThermalSteadyResults: An instance containing steady-state intensity data.
+            SteadyIntensityResults: An instance containing steady-state intensity data.
         """
         if target_temperature is not None:
             self.target_temperature = target_temperature
 
-        return ThermalSteadyResults(
+        return SteadyIntensityResults(
             self.thermal_model.steady_intensity(self.target_temperature)
         )
 

--- a/src/mechaphlowers/core/models/cable/thermal.py
+++ b/src/mechaphlowers/core/models/cable/thermal.py
@@ -132,10 +132,13 @@ class ThermalSteadyResults(ThermalResults):
 
 
 class SteadyIntensityResults(ThermalSteadyResults):
+    """Parser for thermal steady-state intensity computation."""
     pass
 
 
 class SteadyTemperatureResults(ThermalSteadyResults):
+    """Parser for thermal steady-state temperature computation."""
+
     @property
     def uncertainty(self) -> np.ndarray:
         if "uncertainty" in self.data.columns:

--- a/src/mechaphlowers/core/models/cable/thermal.py
+++ b/src/mechaphlowers/core/models/cable/thermal.py
@@ -523,7 +523,9 @@ class ThermalEngine:
         )
 
     def steady_temperature(
-        self, intensity: np.ndarray | None = None
+        self,
+        intensity: np.ndarray | None = None,
+        return_uncertainty: bool = False,
     ) -> ThermalSteadyResults:
         """Compute steady-state temperature results.
 
@@ -534,7 +536,11 @@ class ThermalEngine:
         if intensity is not None:
             self.dict_input["transit"] = intensity
             self.load()
-        return ThermalSteadyResults(self.thermal_model.steady_temperature())
+        return ThermalSteadyResults(
+            self.thermal_model.steady_temperature(
+                return_uncertainty=return_uncertainty
+            )
+        )
 
     def steady_intensity(
         self, target_temperature: np.ndarray | None = None

--- a/src/mechaphlowers/core/models/cable/thermal.py
+++ b/src/mechaphlowers/core/models/cable/thermal.py
@@ -133,6 +133,7 @@ class ThermalSteadyResults(ThermalResults):
 
 class SteadyIntensityResults(ThermalSteadyResults):
     """Parser for thermal steady-state intensity computation."""
+
     pass
 
 

--- a/src/mechaphlowers/core/models/cable/thermal.py
+++ b/src/mechaphlowers/core/models/cable/thermal.py
@@ -141,8 +141,8 @@ class SteadyTemperatureResults(ThermalSteadyResults):
         if "uncertainty" in self.data.columns:
             return self.data["uncertainty"].to_numpy()
         raise UncertaintyNotAvailable(
-            "Uncertainty not available. It is only computed if you pass"
-            " 'return_uncertainty=True' to thermal_engine.steady_temperature."
+            "Uncertainty not available. It hasn't been computed.\n"
+            "To compute it, pass 'return_uncertainty=True' when calling thermal_engine.steady_temperature",
         )
 
 

--- a/src/mechaphlowers/entities/errors.py
+++ b/src/mechaphlowers/entities/errors.py
@@ -79,3 +79,7 @@ class RtsDataNotAvailable(ValueError):
 
 class MeasurementDataNotAvailable(ValueError):
     """Raised when measurement data are not available for computation."""
+
+
+class UncertaintyNotAvailable(AttributeError):
+    """Raised when attempting to read uncertainty while it hasn't been computed."""

--- a/test/core/models/cable/test_thermal.py
+++ b/test/core/models/cable/test_thermal.py
@@ -199,6 +199,20 @@ def test_steady_temperature(thermal_engine_3_spans: ThermalEngine):
     ).all()
 
 
+def test_steady_temperature_with_uncertainty(
+    thermal_engine_3_spans: ThermalEngine,
+) -> None:
+    thermal_engine = thermal_engine_3_spans
+
+    expected_uncertainties = np.array([1.1, 12.7, 5.1])
+
+    results = thermal_engine.steady_temperature(return_uncertainty=True).data
+
+    np.testing.assert_allclose(
+        results["uncertainty"], expected_uncertainties, atol=0.1
+    )
+
+
 def test_wrong_array_length(cable_array_AM600: CableArray):
     thermal_engine = ThermalEngine()
     with pytest.raises(

--- a/test/core/models/cable/test_thermal.py
+++ b/test/core/models/cable/test_thermal.py
@@ -17,6 +17,7 @@ from mechaphlowers.core.models.cable.thermal import (
     to_datetime,
 )
 from mechaphlowers.entities.arrays import CableArray
+from mechaphlowers.entities.errors import UncertaintyNotAvailable
 
 
 @pytest.fixture
@@ -206,11 +207,20 @@ def test_steady_temperature_with_uncertainty(
 
     expected_uncertainties = np.array([1.1, 12.7, 5.1])
 
-    results = thermal_engine.steady_temperature(return_uncertainty=True).data
+    results = thermal_engine.steady_temperature(return_uncertainty=True)
 
     np.testing.assert_allclose(
-        results["uncertainty"], expected_uncertainties, atol=0.1
+        results.uncertainty, expected_uncertainties, atol=0.1
     )
+
+
+def test_steady_temperature_without_uncertainty(
+    thermal_engine_3_spans: ThermalEngine,
+) -> None:
+    thermal_engine = thermal_engine_3_spans
+    results = thermal_engine.steady_temperature()
+    with pytest.raises(UncertaintyNotAvailable):
+        results.uncertainty
 
 
 def test_wrong_array_length(cable_array_AM600: CableArray):

--- a/test/core/models/cable/test_thermal.py
+++ b/test/core/models/cable/test_thermal.py
@@ -228,8 +228,9 @@ def test_steady_temperature_without_uncertainty_explicit(
 ) -> None:
     thermal_engine = thermal_engine_3_spans
     results = thermal_engine.steady_temperature(return_uncertainty=False)
-    with pytest.raises(UncertaintyNotAvailable):
+    with pytest.raises(UncertaintyNotAvailable) as e:
         results.uncertainty
+        print(e)
 
 
 def test_wrong_array_length(cable_array_AM600: CableArray):

--- a/test/core/models/cable/test_thermal.py
+++ b/test/core/models/cable/test_thermal.py
@@ -214,11 +214,20 @@ def test_steady_temperature_with_uncertainty(
     )
 
 
-def test_steady_temperature_without_uncertainty(
+def test_steady_temperature_without_uncertainty_implicit(
     thermal_engine_3_spans: ThermalEngine,
 ) -> None:
     thermal_engine = thermal_engine_3_spans
     results = thermal_engine.steady_temperature()
+    with pytest.raises(UncertaintyNotAvailable):
+        results.uncertainty
+
+
+def test_steady_temperature_without_uncertainty_explicit(
+    thermal_engine_3_spans: ThermalEngine,
+) -> None:
+    thermal_engine = thermal_engine_3_spans
+    results = thermal_engine.steady_temperature(return_uncertainty=False)
     with pytest.raises(UncertaintyNotAvailable):
         results.uncertainty
 

--- a/uv.lock
+++ b/uv.lock
@@ -853,7 +853,7 @@ requires-dist = [
     { name = "pyyaml", specifier = "==6.0.2" },
     { name = "requests", marker = "extra == 'full'", specifier = "==2.33.1" },
     { name = "scipy", marker = "extra == 'full'", specifier = "<=1.14.1" },
-    { name = "thermohl", specifier = "==1.6.0" },
+    { name = "thermohl", specifier = "==1.7.0" },
     { name = "xxhash", specifier = "==3.5.0" },
 ]
 provides-extras = ["full"]
@@ -1967,16 +1967,16 @@ wheels = [
 
 [[package]]
 name = "thermohl"
-version = "1.6.0"
+version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/43/51ff7b3339898a3a57d13e614f7fde1495b0dc9eb772bb0559f8ecd6d3ea/thermohl-1.6.0.tar.gz", hash = "sha256:251e597ea7c59b31e113e4ebdf4776a1ea92e335e66a28b93777ccadb71fb213", size = 1068425, upload-time = "2026-05-28T09:29:30.646Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/61/e9a4b5e5b373a5a03f56f8230bb37c6d0541d9d6b99809b775e3b7942765/thermohl-1.7.0.tar.gz", hash = "sha256:019132e5cdeab59736bb16bbc7436029c87520cb0ee86e16f5d70be5f8d3c08e", size = 1071375, upload-time = "2026-06-04T09:02:44.297Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/8c/99b167619a2758a7f318ad5bf2a7da5bc8a47dde339681402e1063c585e9/thermohl-1.6.0-py3-none-any.whl", hash = "sha256:d05668f3cd6d8ba053bd3b17c65d2be85d1a0e82d41f2b0e1178421511cadd39", size = 76042, upload-time = "2026-05-28T09:29:28.922Z" },
+    { url = "https://files.pythonhosted.org/packages/00/7d/5125e9bf673185326c0ef0fdfc636dc0dbd7d715f4080cb12bc7786341be/thermohl-1.7.0-py3-none-any.whl", hash = "sha256:ac905d19d465a40678496e38e06376f742c8b1d5709be50deba6c3c2d851e32c", size = 77461, upload-time = "2026-06-04T09:02:42.741Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
To be merged after #454 

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

Documentation about the physics is available here (in thermohl docs) : https://phlowers.readthedocs.io/projects/thermohl/en/latest/user-guide/#uncertainty-in-cable-temperature-computation

**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Prepares for https://github.com/phlowers/phlowers-stellar-app/issues/766

Updates thermohl 1.6.0 -> 1.7.0

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes (typing only)
- [ ] No

`thermal_engine.steady_temperature` now returns an instance of `SteadyTemperatureResults` instead of `ThermalSteadyResults`.
`thermal_engine.steady_intensity` now returns an instance of `SteadyIntensityResults` instead of `ThermalSteadyResults`.
