### PR TITLE
refacto(#426): loads from SectionArray to BalanceEngine

### DIFF
--- a/docs/docstring/core/models/balance/span_loads.md
+++ b/docs/docstring/core/models/balance/span_loads.md
@@ -1,0 +1,1 @@
+::: mechaphlowers.core.models.balance.external_loads

--- a/docs/docstring/core/models/balance/span_loads.md
+++ b/docs/docstring/core/models/balance/span_loads.md
@@ -1,1 +1,1 @@
-::: mechaphlowers.core.models.balance.external_loads
+::: mechaphlowers.core.models.balance.span_loads

--- a/docs/user_guide/ug_section_study.md
+++ b/docs/user_guide/ug_section_study.md
@@ -222,16 +222,20 @@ data = study.get_data_spans()
 # tension_sup, tension_inf, L0, horizontal_distance, arc_length, T_h, sag, sag_s2
 ```
 
-## Adding loads
+## Adding point loads
 
 ```python
 import numpy as np
 
-study.add_loads(
-    load_position_distance=np.array([150, 200, 0, np.nan]),
-    load_mass=np.array([500, 70, 0, np.nan]),
+study.set_loads(
+    load_position_distance=np.array([150, 200, 0]),
+    load_mass=np.array([500, 70, 0]),
 )
 ```
+If either load_position_distance[i] or load_mass[i] is zero or nan, it means there is no span load on this span.
+The length of load_position_distance and load_mass is the number of spans.
+
+The used of deprecated method `SectionStudy.add_loads` is discouraged.
 
 ## Plotting
 

--- a/docs/user_guide/ug_section_study.md
+++ b/docs/user_guide/ug_section_study.md
@@ -232,8 +232,8 @@ study.set_loads(
     load_mass=np.array([500, 70, 0]),
 )
 ```
-If either load_position_distance[i] or load_mass[i] is zero or nan, it means there is no span load on this span.
-The length of load_position_distance and load_mass is the number of spans.
+If either `load_position_distance[i]` or `load_mass[i]` is zero or nan, it means there is no span load on this span.
+The length of `load_position_distance` and `load_mass` is the number of spans.
 
 The used of deprecated method `SectionStudy.add_loads` is discouraged.
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -95,6 +95,7 @@ nav:
                       - Cable Strength: docstring/core/models/cable/cable_strength.md
                       - Guying: docstring/core/models/guying.md
                   - External loads: docstring/core/models/external_loads.md
+                  - Point loads: docstring/core/models/balance/span_loads.md
               - Papoto: docstring/core/papoto/papoto_model.md
           - Data:
               - Catalog: docstring/data/catalog/catalog.md

--- a/src/mechaphlowers/api/section_study.py
+++ b/src/mechaphlowers/api/section_study.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import TYPE_CHECKING, Type
 
 import numpy as np
@@ -33,6 +34,7 @@ if TYPE_CHECKING:
     from mechaphlowers.core.models.cable.thermal import ThermalEngine
     from mechaphlowers.core.models.guying import Guying
     from mechaphlowers.plotting.plot import PlotEngine
+from mechaphlowers.utils import arr
 
 logger = logging.getLogger(__name__)
 
@@ -397,13 +399,44 @@ class SectionStudy:
         load_position_distance: np.ndarray | list,
         load_mass: np.ndarray | list,
     ) -> None:
-        """Delegate to [`BalanceEngine.add_loads`][mechaphlowers.core.models.balance.engine.BalanceEngine.add_loads].
+        """Calls preferred method [`set_loads`](mechaphlowers.api.section_study.SectionStudy.set_loads).
+
+        This method is kept for compatibility.
+
+        Expected length for load_position_distance and load_mass is the number of pylons. Last array elements should be nan
+        or zero.
+
+        Raises:
+            ValueError: if at least one load_position_distance is not in [0, span_length]
+                or if the arguments don't have the right lengths.
+        """
+        warnings.warn(
+            "add_loads is deprecated, use set_loads instead."
+            "Caution: expected argument length for set_loads is the number of spans.",
+            category=DeprecationWarning,
+        )
+        load_position_distance = np.array(load_position_distance)
+        load_mass = np.array(load_mass)
+        self.set_loads(arr.decr(load_position_distance), arr.decr(load_mass))
+
+    def set_loads(
+        self,
+        load_position_distance: np.ndarray | list,
+        load_mass: np.ndarray | list,
+    ) -> None:
+        """Delegate to [`BalanceEngine.set_loads`][mechaphlowers.core.models.balance.engine.BalanceEngine.set_loads].
+
+        If either load_position_distance[i] or load_mass[i] is 0 or nan, it means there is no load at span i.
 
         Args:
-            load_position_distance (np.ndarray | list): Position of the loads, in meters.
-            load_mass (np.ndarray | list): Mass of the loads.
+            load_position_distance (np.ndarray | list): Position of the loads, in meters. Its size must be the number of spans.
+            load_mass (np.ndarray | list): Mass of the loads. Its size must be the number of spans.
+
+        Raises:
+            ValueError: if at least one load_position_distance is not in [0, span_length]
+                or if the arguments don't have the right lengths.
         """
-        self._balance_engine.add_loads(load_position_distance, load_mass)
+        self._balance_engine.set_loads(load_position_distance, load_mass)
 
     # ── State management ──────────────────────────────────────────────────
 

--- a/src/mechaphlowers/core/models/balance/engine.py
+++ b/src/mechaphlowers/core/models/balance/engine.py
@@ -20,6 +20,7 @@ from mechaphlowers.core.models.balance.models.model_ducloux import BalanceModel
 from mechaphlowers.core.models.balance.solvers.balance_solver import (
     BalanceSolver,
 )
+from mechaphlowers.core.models.balance.span_loads import SpanLoads
 from mechaphlowers.core.models.cable.deformation import (
     DeformationRte,
     IDeformation,
@@ -105,7 +106,7 @@ class BalanceEngine(Notifier):
     def reset(self, full: bool = False) -> None:
         """Reset the balance engine to initial state.
 
-        This method re-initializes the span model, cable loads, deformation model, balance model, and solvers.
+        This method re-initializes the span model, cable loads, span loads, deformation model, balance model, and solvers.
         This method is useful when an error occurs during solving that may cause an inconsistent state with NaN values.
         """
 
@@ -131,6 +132,11 @@ class BalanceEngine(Notifier):
                 zeros_vector,
                 zeros_vector,
             )
+            self.span_loads = SpanLoads(
+                arr.decr(zeros_vector),
+                arr.decr(zeros_vector),
+                self.section_array.data.span_length.to_numpy(),
+            )
             self.deformation_model = deformation_model_builder(
                 self.cable_array,
                 self.span_model,
@@ -146,6 +152,7 @@ class BalanceEngine(Notifier):
                 self.span_model,
                 self.deformation_model,
                 self.cable_loads,
+                self.span_loads,
             )
         else:
             self.balance_model.reset(
@@ -153,6 +160,7 @@ class BalanceEngine(Notifier):
                 span_model=self.span_model,
                 deformation_model=self.deformation_model,
                 cable_loads=self.cable_loads,
+                span_loads=self.span_loads,
                 full=full,
             )
 
@@ -179,42 +187,62 @@ class BalanceEngine(Notifier):
         load_position_distance: np.ndarray | list,
         load_mass: np.ndarray | list,
     ) -> None:
+        """Calls preferred method [`set_loads`](mechaphlowers.core.models.balance.engine.BalanceEngine.set_loads).
+
+        Kept for compatibility.
+
+        Expected length for load_position_distance and load_mass is the number of pylons.
+        Last array elements should be nan or zero.
+
+        Raises:
+            ValueError: if at least one load_position_distance is not in [0, span_length]
+                or if the arguments don't have the right lengths.
+        """
+        warnings.warn(
+            "add_loads is deprecated, use set_loads instead."
+            "Caution: expected argument length for set_loads is the number of spans.",
+            category=DeprecationWarning,
+        )
+        load_position_distance = np.array(load_position_distance)
+        load_mass = np.array(load_mass)
+        self.set_loads(arr.decr(load_position_distance), arr.decr(load_mass))
+
+    def set_loads(
+        self,
+        load_position_distance: np.ndarray | list,
+        load_mass: np.ndarray | list,
+    ) -> None:
         """Adds loads to BalanceEngine.
-        Updates load_position and load_mass fields in SectionArray.
 
-        Input for position is a distance, and will be converted into ratio to match SectionArray.
+        Input for position is a distance, and will be converted into ratio.
 
-        Expected input are arrays of size matching the number of supports. Each value refers to a span.
+        Expected input are arrays of size matching the number of spans. Each value refers to a span.
+        Last elements should be nan or zero.
+
+        If either load_position_distance[i] or load_mass[i] is 0 or nan, it means there is no load at span i.
 
         Args:
             load_position_distance (np.ndarray | list): Position of the loads, in meters
             load_mass (np.ndarray | list): Mass of the loads
 
         Raises:
-            ValueError: if load_position_distance is not in [0, span_length] for at least one span
+            ValueError: if at least one load_position_distance is not in [0, span_length]
+                or if the arguments don't have the right lengths.
 
         Examples:
-            >>> load_position_distance = np.array([150, 200, 0, np.nan])  # 4 supports/3 spans
-            >>> load_mass = np.array([500, 70, 0, np.nan])
-            >>> engine.add_loads(load_position_distance, load_mass)
+            >>> load_position_distance = np.array([150, 200, 0])  # 3 spans
+            >>> load_mass = np.array([500, 70, 0])
+            >>> engine.set_loads(load_position_distance, load_mass)
             >>> plot_engine.reset()  # optional: only needed if cached plots must be discarded
         """
-        span_length = self.section_array.data["span_length"].to_numpy()
-        load_position_distance = np.array(load_position_distance)
-        if (
-            arr.decr(load_position_distance > span_length).any()
-            or arr.decr(load_position_distance < 0).any()
-        ):
-            raise ValueError(
-                f"{load_position_distance=} should be all between 0 and {span_length=}"
-            )
+        span_length = self.section_array.data.span_length.to_numpy()
 
-        # This formula for load_position_ratio may change later
-        load_position_ratio = load_position_distance / span_length
-        self.section_array._data["load_position"] = load_position_ratio
-        self.section_array._data["load_mass"] = load_mass
+        self.span_loads.set_loads(
+            load_position_distance, load_mass, span_length
+        )
 
         self.reset(full=False)
+
         debug_loads = (
             "Loads have been added. PlotEngine will be notified automatically "
             "via the observer pattern; no manual reset is required."
@@ -454,6 +482,8 @@ class BalanceEngine(Notifier):
             f"wind: {self.balance_model.cable_loads.wind_pressure}\n"
             f"ice: {self.balance_model.cable_loads.ice_thickness}\n"
             f"temperature: {self.balance_model.sagging_temperature}\n"
+            f"load position (ratio): {self.span_loads.load_position}\n"
+            f"load mass: {self.span_loads.load_mass}\n"
             f"dx: {dxdydz[0]}\n"
             f"dy: {dxdydz[1]}\n"
             f"dz: {dxdydz[2]}\n"

--- a/src/mechaphlowers/core/models/balance/interfaces.py
+++ b/src/mechaphlowers/core/models/balance/interfaces.py
@@ -18,6 +18,7 @@ from mechaphlowers.core.models.balance.solvers.find_parameter_solver import (
     FindParamSolverForLoop,
     IFindParamSolver,
 )
+from mechaphlowers.core.models.balance.span_loads import SpanLoads
 from mechaphlowers.core.models.cable.deformation import IDeformation
 from mechaphlowers.core.models.cable.span import ISpan
 from mechaphlowers.core.models.external_loads import CableLoads
@@ -72,6 +73,7 @@ class IBalanceModel(IModelForSolver, ABC):
         span_model: ISpan,
         deformation_model: IDeformation,
         cable_loads: CableLoads,
+        span_loads: SpanLoads,
         find_param_solver_type: Type[
             IFindParamSolver
         ] = FindParamSolverForLoop,
@@ -80,6 +82,7 @@ class IBalanceModel(IModelForSolver, ABC):
         self.sagging_temperature: np.ndarray = sagging_temperature
         self.deformation_model = deformation_model
         self.cable_loads = cable_loads
+        self.span_loads = span_loads
         self.span_model = span_model
         self.nodes_span_model: ISpan = copy(self.span_model)
         self.parameter: np.ndarray = parameter
@@ -188,6 +191,7 @@ class IBalanceModel(IModelForSolver, ABC):
         span_model: ISpan,
         deformation_model: IDeformation,
         cable_loads: CableLoads,
+        span_loads: SpanLoads,
         full: bool = False,
     ) -> None:
         """Reset the model references, optionally performing a full re-initialization.
@@ -197,8 +201,13 @@ class IBalanceModel(IModelForSolver, ABC):
             span_model (ISpan): span model
             deformation_model (IDeformation): deformation model
             cable_loads (CableLoads): cable loads
+            span_loads (SpanLoads): span loads
             full (bool): if True, re-initialize all attributes; otherwise only update model references.
         """
+        pass
+
+    @abstractmethod
+    def initialize_loadmodel(self) -> None:
         pass
 
     @abstractmethod

--- a/src/mechaphlowers/core/models/balance/memento.py
+++ b/src/mechaphlowers/core/models/balance/memento.py
@@ -14,6 +14,7 @@ import numpy as np
 
 if TYPE_CHECKING:
     from mechaphlowers.core.models.balance.engine import BalanceEngine
+from mechaphlowers.core.models.balance.span_loads import SpanLoads
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,10 @@ class BalanceEngineMemento:
     # --- cable_loads ---
     wind_pressure: np.ndarray
     ice_thickness: np.ndarray
+
+    # --- span loads ---
+    load_position: np.ndarray
+    load_mass: np.ndarray
 
     # --- deformation_model ---
     deformation_current_temperature: np.ndarray
@@ -95,6 +100,8 @@ class BalanceEngineCaretaker:
             span_load_coefficient=engine.span_model.load_coefficient.copy(),
             wind_pressure=engine.cable_loads.wind_pressure.copy(),
             ice_thickness=engine.cable_loads.ice_thickness.copy(),
+            load_position=engine.span_loads.load_position.copy(),
+            load_mass=engine.span_loads.load_mass.copy(),
             deformation_current_temperature=engine.deformation_model.current_temperature.copy(),
             deformation_tension_mean=engine.deformation_model.tension_mean.copy(),
             deformation_cable_length=engine.deformation_model.cable_length.copy(),
@@ -117,9 +124,7 @@ class BalanceEngineCaretaker:
         engine = self._engine
         bm = engine.balance_model
 
-        # (a) Restore nodes — in-place write preserves array identity
-
-        # (b) Restore balance_model scalars / arrays
+        # (a) Restore balance_model scalars / arrays
         bm.parameter = memento.parameter.copy()
         bm.sagging_temperature = memento.sagging_temperature.copy()
         bm.adjustment = memento.adjustment
@@ -129,7 +134,7 @@ class BalanceEngineCaretaker:
         bm.a = memento.a.copy()
         bm.b = memento.b.copy()
 
-        # (c) Restore span_model arrays + refresh cached _x_m/_x_n/_L
+        # (b) Restore span_model arrays + refresh cached _x_m/_x_n/_L
         engine.span_model.parameter = memento.span_sagging_parameter.copy()
         engine.span_model.span_length = memento.span_span_length.copy()
         engine.span_model.elevation_difference = (
@@ -140,9 +145,13 @@ class BalanceEngineCaretaker:
         )
         engine.span_model.compute_values()
 
-        # (d) Restore cable_loads
+        # (c) Restore cable_loads
         engine.cable_loads.wind_pressure = memento.wind_pressure.copy()
         engine.cable_loads.ice_thickness = memento.ice_thickness.copy()
+
+        # (d) Restore span loads
+        engine.span_loads.load_position = memento.load_position.copy()
+        engine.span_loads.load_mass = memento.load_mass.copy()
 
         # (e) Restore deformation_model (snapshots, not refs)
         engine.deformation_model.current_temperature = (
@@ -162,7 +171,12 @@ class BalanceEngineCaretaker:
             del engine.L_ref
 
         # (g) Re-sync derived objects
-
+        bm.nodes.load_position = engine.span_loads.load_position.copy()
+        bm.nodes.load_weight = engine.span_loads.load_weight.copy()
+        bm.nodes.has_load_on_span = SpanLoads.compute_has_load_on_span(
+            bm.nodes.load_weight, bm.nodes.load_position
+        )
+        bm.initialize_loadmodel()
         bm.sync_after_memento_restore(engine.span_model, memento.dxdydz)
 
         logger.debug("Balance engine state restored from memento.")

--- a/src/mechaphlowers/core/models/balance/models/model_ducloux.py
+++ b/src/mechaphlowers/core/models/balance/models/model_ducloux.py
@@ -31,6 +31,7 @@ from mechaphlowers.core.models.balance.solvers.find_parameter_solver import (
     FindParamSolverForLoop,
     IFindParamSolver,
 )
+from mechaphlowers.core.models.balance.span_loads import SpanLoads
 from mechaphlowers.core.models.cable.deformation import (
     IDeformation,
     deformation_model_builder,
@@ -84,18 +85,24 @@ class BalanceModel(IBalanceModel):
         span_model: ISpan,
         deformation_model: IDeformation,
         cable_loads: CableLoads,
+        span_loads: SpanLoads,
         find_param_solver_type: Type[
             IFindParamSolver
         ] = FindParamSolverForLoop,
     ) -> None:
-        # tempertaure and parameter size n-1 here
+        # temperature and parameter size n-1 here
         self.sagging_temperature = sagging_temperature
         self.parameter_init = parameter
         self.section_array = section_array
         self.find_param_solver_type = find_param_solver_type
 
         self.reset(
-            cable_array, span_model, deformation_model, cable_loads, full=True
+            cable_array,
+            span_model,
+            deformation_model,
+            cable_loads,
+            span_loads,
+            full=True,
         )
         self.nodes: Nodes
 
@@ -105,6 +112,7 @@ class BalanceModel(IBalanceModel):
         span_model: ISpan,
         deformation_model: IDeformation,
         cable_loads: CableLoads,
+        span_loads: SpanLoads,
         full: bool = False,
     ) -> None:
         """set or reset the model.
@@ -133,10 +141,10 @@ class BalanceModel(IBalanceModel):
         self.parameter = self.parameter_init
         self.initialize_cable(cable_array)
 
-        self.nodes = nodes_builder(self.section_array)
+        self.nodes = nodes_builder(self.section_array, span_loads)
 
         self.initialize_models_references(
-            span_model, deformation_model, cable_loads, full=full
+            span_model, deformation_model, cable_loads, span_loads, full=full
         )
 
         # TODO: during adjustment computation, perhaps set cable_temperature = 0
@@ -161,6 +169,7 @@ class BalanceModel(IBalanceModel):
         span_model: ISpan,
         deformation_model: IDeformation,
         cable_loads: CableLoads,
+        span_loads: SpanLoads,
         full: bool = False,
     ):
         """Initialize or reset models references. Special behavior for nodes_span_model if full is False to avoid breaking references.
@@ -178,8 +187,9 @@ class BalanceModel(IBalanceModel):
             self.nodes_span_model.mirror(self.span_model)
         self.deformation_model = deformation_model
         self.cable_loads = cable_loads
+        self.span_loads = span_loads
 
-    def initialize_loadmodel(self):
+    def initialize_loadmodel(self) -> None:
         """Initialize LoadModel object used in change_state case with loads."""
         self.load_model = LoadModel(
             self.cable_array,
@@ -965,11 +975,12 @@ class Nodes:
         return self.__repr__()
 
 
-def nodes_builder(section_array: SectionArray) -> Nodes:
-    """Builds a Nodes object from a SectionArray by extracting and transforming data.
+def nodes_builder(section_array: SectionArray, span_loads: SpanLoads) -> Nodes:
+    """Builds a Nodes object from a SectionArray and a SpanLoads by extracting and transforming data.
 
     Args:
         section_array (SectionArray): Section Array to extract the data from.
+        span_loads (SpanLoads): SpanLoad representing point loads.
 
     Returns:
         Nodes: An instance of Nodes initialized with data from section array.
@@ -986,16 +997,9 @@ def nodes_builder(section_array: SectionArray) -> Nodes:
     )
     span_length = arr.decr(section_array.data.span_length.to_numpy())
 
-    load_weight = (
-        arr.decr(section_array.data.load_weight.to_numpy())
-        if "load_weight" in section_array.data
-        else np.zeros(span_length.shape)
-    )
-    load_position = (
-        arr.decr(section_array.data.load_position.to_numpy())
-        if "load_position" in section_array.data
-        else np.zeros(span_length.shape)
-    )
+    load_weight = span_loads.load_weight
+    load_position = span_loads.load_position.copy()
+
     counterweight = (
         section_array.data.counterweight.to_numpy()
         if "counterweight" in section_array.data

--- a/src/mechaphlowers/core/models/balance/span_loads.py
+++ b/src/mechaphlowers/core/models/balance/span_loads.py
@@ -1,0 +1,110 @@
+import numpy as np
+
+from mechaphlowers.data.units import convert_mass_to_weight
+from mechaphlowers.utils import arr
+
+
+class SpanLoads:
+    def __init__(
+        self,
+        load_position_distance: np.ndarray | list,
+        load_mass: np.ndarray | list,
+        span_length: np.ndarray | list,
+    ):
+        """Create an oject to store discrete loads.
+
+        NB: The length of load_position_distance and load_mass must be the number of spans.
+        The length of span_length must be the number of pylons (same as SectionArray.data.span_length).
+        """
+        self.set_loads(load_position_distance, load_mass, span_length)
+
+    def set_loads(
+        self,
+        load_position_distance: np.ndarray | list,
+        load_mass: np.ndarray | list,
+        span_length: np.ndarray | list,
+    ) -> None:
+        """Set loads.
+
+        Input for position is a distance, and will be converted into ratio.
+
+        Expected length of load_position_distance and load_mass is the number of spans. Each value refers to a span.
+        Last elements should be nan or zero. Expected length of span_length is the number of pylons (same as
+        SectionArray.data.span_length).
+
+        If either load_position_distance[i] or load_mass[i] is 0 or nan, it means there is no load at span i.
+
+        Args:
+            load_position_distance (np.ndarray | list): Position of the loads, in meters
+            load_mass (np.ndarray | list): Mass of the loads
+
+        Raises:
+            ValueError: if at least one load_position_distance is not in [0, span_length],
+                or if the arguments don't have the right lengths.
+        """
+        load_position_distance, load_mass, span_length = (
+            self._validate_load_arguments(
+                load_position_distance,
+                load_mass,
+                span_length,
+            )
+        )
+        self.load_position = self._compute_load_position_ratio(
+            load_position_distance, span_length
+        )
+        self.load_mass = load_mass
+
+    @staticmethod
+    def _validate_load_arguments(
+        load_position_distance: np.ndarray | list,
+        load_mass: np.ndarray | list,
+        span_length: np.ndarray | list,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        if len(load_position_distance) != len(load_mass):
+            raise ValueError(
+                "load_position_distance and load_mass must have the same length. "
+                f"Got {len(load_position_distance)=} and {len(load_mass)=}"
+            )
+        if len(load_position_distance) + 1 != len(span_length):
+            raise ValueError(
+                "Length of load_position_distance must be length of span_length - 1. "
+                f"Got {len(load_position_distance)=} and {len(span_length)=}"
+            )
+
+        load_position_distance = np.array(load_position_distance)
+        span_length = np.array(span_length)
+        if (load_position_distance > arr.decr(span_length)).any() or (
+            load_position_distance < 0
+        ).any():
+            raise ValueError(
+                f"{load_position_distance=} should be all between 0 and {span_length=}"
+            )
+        load_mass = np.array(load_mass)
+        return load_position_distance, load_mass, span_length
+
+    @staticmethod
+    def _compute_load_position_ratio(
+        load_position_distance: np.ndarray, span_length: np.ndarray
+    ) -> np.ndarray:
+        # Length of span_length must be length of load_position_distance + 1
+        # This formula for load_position_ratio may change later
+        return load_position_distance / arr.decr(span_length)
+
+    @property
+    def load_weight(self) -> np.ndarray:
+        return convert_mass_to_weight(self.load_mass)
+
+    @property
+    def has_load_on_span(self) -> np.ndarray:
+        return self.compute_has_load_on_span(
+            self.load_weight, self.load_position
+        )
+
+    @staticmethod
+    def compute_has_load_on_span(load_weight, load_position) -> np.ndarray:
+        return (
+            np.logical_not(np.isnan(load_weight))
+            & np.logical_not(np.isnan(load_position))
+            & (load_weight != 0)
+            & (load_position != 0)
+        )

--- a/src/mechaphlowers/core/models/balance/span_loads.py
+++ b/src/mechaphlowers/core/models/balance/span_loads.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2026, RTE (http://www.rte-france.com)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+
 import numpy as np
 
 from mechaphlowers.data.units import convert_mass_to_weight

--- a/src/mechaphlowers/entities/arrays.py
+++ b/src/mechaphlowers/entities/arrays.py
@@ -134,7 +134,6 @@ class SectionArray(ElementArray):
         "insulator_length": "m",
         "span_length": "m",
         "insulator_mass": "kg",
-        "load_mass": "kg",
         "counterweight_mass": "kg",
         "sagging_parameter": "m",
         "sagging_temperature": "°C",
@@ -307,7 +306,6 @@ class SectionArray(ElementArray):
         data_output = super().data
         mass_weight_conversion = {
             "insulator_mass": "insulator_weight",
-            "load_mass": "load_weight",
             "counterweight_mass": "counterweight",
         }
         self.create_column_weight(data_output, mass_weight_conversion)

--- a/src/mechaphlowers/entities/schemas.py
+++ b/src/mechaphlowers/entities/schemas.py
@@ -36,13 +36,6 @@ class SectionArrayInput(pa.DataFrameModel):
     insulator_length: pdt.Series[float] = pa.Field(coerce=True)
     span_length: pdt.Series[float] = pa.Field(nullable=True, coerce=True)
     insulator_mass: pdt.Series[float] = pa.Field(coerce=True)
-    load_mass: pdt.Series[float] | None = pa.Field(
-        nullable=True,
-        coerce=True,
-    )
-    load_position: pdt.Series[float] | None = pa.Field(
-        nullable=True, coerce=True, ge=0, le=1
-    )
     ground_altitude: pdt.Series[float] | None = pa.Field(
         nullable=True, coerce=True
     )

--- a/test/api/test_section_study.py
+++ b/test/api/test_section_study.py
@@ -102,7 +102,6 @@ class TestSectionStudyLifecycle:
             vhl_after_change_state.vhl_matrix.value(),
         )
 
-    @pytest.mark.skip(reason="Fix this later when refacto add_loads")
     def test_save_restore_loads(self, cable_array_AM600: CableArray):
         section_array = SectionArray(
             pd.DataFrame(
@@ -115,8 +114,6 @@ class TestSectionStudyLifecycle:
                     "insulator_length": [3, 3, 3, 3],
                     "span_length": [500, 500, 500, np.nan],
                     "insulator_mass": [100.0, 50.0, 50.0, 100.0],
-                    "load_mass": [0, 0, 0, 0],
-                    "load_position": [0, 0, 0, 0],
                 }
             ),
             sagging_parameter=2000,
@@ -133,9 +130,9 @@ class TestSectionStudyLifecycle:
         memento = study.save_state()
 
         # test that using restore reverts correcty
-        study.add_loads(
-            load_position_distance=np.array([0, 300, 0, 0]),
-            load_mass=np.array([0, 100, 0, 0]),
+        study.set_loads(
+            load_position_distance=np.array([0, 300, 0]),
+            load_mass=np.array([0, 100, 0]),
         )
         study.solve_change_state()
         study.restore_state(memento)

--- a/test/benchmark/test_model_ducloux_profiling.py
+++ b/test/benchmark/test_model_ducloux_profiling.py
@@ -52,8 +52,6 @@ def test_load_all_spans_wind_ice_temp_profiling():
                 "insulator_length": [3, 3, 3, 3],
                 "span_length": [500, 300, 400, np.nan],
                 "insulator_mass": [1000, 500, 500, 1000],
-                "load_mass": [500, 1000, 500, np.nan],
-                "load_position": [0.2, 0.4, 0.6, np.nan],
             }
         ),
         sagging_parameter=2000,
@@ -92,8 +90,6 @@ def test_many_spans(cable_array_AM600: CableArray):
                 "insulator_length": [3] * nb_spans,
                 "span_length": [500] * (nb_spans - 1) + [np.nan],
                 "insulator_mass": [500 / 9.81] * nb_spans,
-                "load_mass": [0] * nb_spans,
-                "load_position": [0] * nb_spans,
             }
         ),
         sagging_parameter=2000,
@@ -127,8 +123,6 @@ def test_many_spans_with_load(cable_array_AM600: CableArray):
                 "insulator_length": [3] * nb_spans,
                 "span_length": [500] * (nb_spans - 1) + [np.nan],
                 "insulator_mass": [500 / 9.81] * nb_spans,
-                "load_mass": [500 / 9.81] * nb_spans,
-                "load_position": [0.5] * nb_spans,
             }
         ),
         sagging_parameter=2000,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -24,6 +24,7 @@ projet_dir: Path = Path(__file__).resolve().parents[1]
 source_dir: Path = projet_dir / "src"
 sys.path.append(str(source_dir))
 
+from mechaphlowers.core.models.balance.span_loads import SpanLoads
 from mechaphlowers.entities.arrays import (
     CableArray,
     SectionArray,
@@ -170,6 +171,14 @@ def section_array_complete() -> SectionArray:
 
 
 @pytest.fixture
+def span_loads_for_complete_section_array() -> SpanLoads:
+    load_position_distance = np.array([0, 250, 100])
+    load_mass = np.array([0, 0, 70])
+    span_length = np.array([500, 300, 400, np.nan])
+    return SpanLoads(load_position_distance, load_mass, span_length)
+
+
+@pytest.fixture
 def factory_neutral_weather_array() -> Callable[[int], WeatherArray]:
     def _method_cable_array(nb_span=2):
         return WeatherArray(
@@ -289,8 +298,6 @@ def balance_engine_base_test(cable_array_AM600: CableArray) -> BalanceEngine:
                 "insulator_mass": convert_weight_to_mass(
                     [1000.0, 500.0, 500.0, 1000.0]
                 ),
-                "load_mass": [0, 0, 0, 0],
-                "load_position": [0, 0, 0, 0],
             }
         ),
         sagging_parameter=2000,

--- a/test/core/geometry/test_position_engine.py
+++ b/test/core/geometry/test_position_engine.py
@@ -129,16 +129,16 @@ class TestPositionEngineReactivity:
             balance_engine_base_test.solve_change_state(new_temperature=50)
             mock_reset.assert_not_called()
 
-    def test_add_loads_triggers_reset(
+    def test_set_loads_triggers_reset(
         self, balance_engine_base_test: BalanceEngine
     ):
         pos_engine = PositionEngine(balance_engine_base_test)
         with patch.object(
             pos_engine, "reset", wraps=pos_engine.reset
         ) as mock_reset:
-            balance_engine_base_test.add_loads(
-                load_position_distance=np.array([0, 0, 0, np.nan]),
-                load_mass=np.array([0, 0, 0, np.nan]),
+            balance_engine_base_test.set_loads(
+                load_position_distance=np.array([0, 0, 0]),
+                load_mass=np.array([0, 0, 0]),
             )
             mock_reset.assert_called_once_with(
                 balance_engine=balance_engine_base_test
@@ -152,9 +152,9 @@ class TestPositionEngineReactivity:
         downstream = ConcreteObserver()
         pos_engine.bind_to(downstream)
 
-        balance_engine_base_test.add_loads(
-            load_position_distance=np.array([0, 0, 0, np.nan]),
-            load_mass=np.array([0, 0, 0, np.nan]),
+        balance_engine_base_test.set_loads(
+            load_position_distance=np.array([0, 0, 0]),
+            load_mass=np.array([0, 0, 0]),
         )
 
         assert downstream.call_count == 1
@@ -169,9 +169,9 @@ class TestPositionEngineReactivity:
             "reset",
             wraps=pos_engine.coords_calculator.reset,
         ) as mock_reset:
-            balance_engine_base_test.add_loads(
-                load_position_distance=np.array([0, 0, 0, np.nan]),
-                load_mass=np.array([0, 0, 0, np.nan]),
+            balance_engine_base_test.set_loads(
+                load_position_distance=np.array([0, 0, 0]),
+                load_mass=np.array([0, 0, 0]),
             )
             mock_reset.assert_called_once()
 
@@ -195,9 +195,9 @@ class TestPositionEngineReferenceIntegrity:
         pos_engine = PositionEngine(balance_engine_base_test)
         original_id = id(pos_engine.span_model)
 
-        balance_engine_base_test.add_loads(
-            load_position_distance=np.array([0, 0, 0, np.nan]),
-            load_mass=np.array([0, 0, 0, np.nan]),
+        balance_engine_base_test.set_loads(
+            load_position_distance=np.array([0, 0, 0]),
+            load_mass=np.array([0, 0, 0]),
         )
 
         assert id(pos_engine.span_model) == original_id
@@ -211,9 +211,9 @@ class TestPositionEngineReferenceIntegrity:
     ):
         pos_engine = PositionEngine(balance_engine_base_test)
 
-        balance_engine_base_test.add_loads(
-            load_position_distance=np.array([0, 0, 0, np.nan]),
-            load_mass=np.array([0, 0, 0, np.nan]),
+        balance_engine_base_test.set_loads(
+            load_position_distance=np.array([0, 0, 0]),
+            load_mass=np.array([0, 0, 0]),
         )
 
         x_expected, _ = pos_engine.span_model.get_coords(

--- a/test/core/models/balance/models/test_model_ducloux.py
+++ b/test/core/models/balance/models/test_model_ducloux.py
@@ -12,11 +12,17 @@ from mechaphlowers.core.models.balance.engine import BalanceEngine
 from mechaphlowers.core.models.balance.models.model_ducloux import (
     nodes_builder,
 )
+from mechaphlowers.core.models.balance.span_loads import SpanLoads
 from mechaphlowers.entities.arrays import CableArray, SectionArray
 
 
-def test_section_array_to_nodes(section_array_complete: SectionArray):
-    nodes_builder(section_array_complete)
+def test_nodes_builder(
+    section_array_complete: SectionArray,
+    span_loads_for_complete_section_array: SpanLoads,
+):
+    nodes_builder(
+        section_array_complete, span_loads_for_complete_section_array
+    )
 
 
 def test_load_span_model(cable_array_AM600: CableArray):
@@ -31,8 +37,6 @@ def test_load_span_model(cable_array_AM600: CableArray):
                 "insulator_length": [3, 3, 3, 3],
                 "span_length": [500, 300, 400, np.nan],
                 "insulator_mass": [100, 50, 500, 0],
-                "load_mass": [0, 500, 0, np.nan],
-                "load_position": [0.2, 0.4, 0.6, np.nan],
             }
         ),
         sagging_parameter=2000,
@@ -44,7 +48,10 @@ def test_load_span_model(cable_array_AM600: CableArray):
         cable_array=cable_array_AM600,
         section_array=section_array,
     )
-
+    balance_engine.set_loads(
+        load_position_distance=[100, 120, 240],
+        load_mass=[0, 500, 0],
+    )
     balance_engine.solve_adjustment()
 
     balance_engine.solve_change_state()

--- a/test/core/models/balance/models/test_model_ducloux_integration.py
+++ b/test/core/models/balance/models/test_model_ducloux_integration.py
@@ -614,8 +614,6 @@ def test_load_all_spans(cable_array_AM600: CableArray):
                 "insulator_mass": convert_weight_to_mass(
                     [1000, 500, 500, 1000]
                 ),
-                "load_mass": convert_weight_to_mass([500, 1000, 500, np.nan]),
-                "load_position": [0.2, 0.4, 0.6, np.nan],
             }
         ),
         sagging_parameter=2000,
@@ -626,6 +624,10 @@ def test_load_all_spans(cable_array_AM600: CableArray):
     balance_engine_angles_arm = BalanceEngine(
         cable_array=cable_array_AM600,
         section_array=section_array,
+    )
+    balance_engine_angles_arm.set_loads(
+        load_position_distance=[100, 120, 240],
+        load_mass=convert_weight_to_mass([500, 1000, 500]),
     )
 
     balance_engine_angles_arm.solve_adjustment()
@@ -703,6 +705,10 @@ def test_load_all_spans_wind_ice_temp(cable_array_AM600: CableArray):
         section_array=section_array,
     )
 
+    balance_engine_angles_arm.set_loads(
+        load_position_distance=[100, 120, 240],
+        load_mass=convert_weight_to_mass([500, 1000, 500]),
+    )
     balance_engine_angles_arm.solve_adjustment()
     new_temperature = np.array([30] * 4)
     ice_thickness = np.array([1] * 4) * 1e-2
@@ -780,6 +786,10 @@ def test_load_one_span(cable_array_AM600: CableArray):
     balance_engine_angles_arm = BalanceEngine(
         cable_array=cable_array_AM600,
         section_array=section_array,
+    )
+    balance_engine_angles_arm.set_loads(
+        load_position_distance=[100, 120, 250],
+        load_mass=convert_weight_to_mass([0, 1000, 0]),
     )
 
     balance_engine_angles_arm.solve_adjustment()

--- a/test/core/models/balance/test_engine.py
+++ b/test/core/models/balance/test_engine.py
@@ -222,8 +222,6 @@ def test_load_span__node_span_coherence_with_balance_model(
                 "insulator_length": [3, 3, 3, 3],
                 "span_length": [500, 300, 400, np.nan],
                 "insulator_mass": [100, 50, 50, 100],
-                "load_mass": [0, 1000, 0, np.nan],
-                "load_position": [0.2, 0.4, 0.6, np.nan],
             }
         ),
         sagging_parameter=2000,
@@ -235,7 +233,10 @@ def test_load_span__node_span_coherence_with_balance_model(
         cable_array=cable_array_AM600,
         section_array=section_array,
     )
-
+    balance_engine_angles_arm.set_loads(
+        load_position_distance=[100, 120, 240],
+        load_mass=[0, 1000, 0],
+    )
     balance_engine_angles_arm.solve_adjustment()
 
     balance_engine_angles_arm.solve_change_state()
@@ -264,8 +265,6 @@ def test_load_span__check_node_span_changes(cable_array_AM600: CableArray):
                 "insulator_length": [3, 3, 3, 3],
                 "span_length": [500, 300, 400, np.nan],
                 "insulator_mass": [100, 50, 50, 100],
-                "load_mass": [0, 1000, 0, np.nan],
-                "load_position": [0.2, 0.4, 0.6, np.nan],
             }
         ),
         sagging_parameter=2000,
@@ -276,6 +275,10 @@ def test_load_span__check_node_span_changes(cable_array_AM600: CableArray):
     balance_engine_angles_arm = BalanceEngine(
         cable_array=cable_array_AM600,
         section_array=section_array,
+    )
+    balance_engine_angles_arm.set_loads(
+        load_position_distance=[100, 120, 240],
+        load_mass=[0, 1000, 0],
     )
 
     span_model_1 = deepcopy(
@@ -375,11 +378,11 @@ def test_reset_restores_initial_state(balance_engine_simple: BalanceEngine):
 def test_add_loads_wrong_values(balance_engine_simple: BalanceEngine):
     load_mass = np.array([500, 70, 0, np.nan])
     with pytest.raises(ValueError):
-        balance_engine_simple.add_loads(
+        balance_engine_simple.set_loads(
             np.array([-1, 200, 0, np.nan]), load_mass
         )
     with pytest.raises(ValueError):
-        balance_engine_simple.add_loads(
+        balance_engine_simple.set_loads(
             np.array([0, 1000, 0, np.nan]), load_mass
         )
 
@@ -408,9 +411,9 @@ def test_get_data_spans(balance_engine_simple: BalanceEngine):
 
 
 def test_get_data_spans_with_loads(balance_engine_simple: BalanceEngine):
-    balance_engine_simple.add_loads(
-        load_position_distance=[150, 200, 0, np.nan],
-        load_mass=[200, 500, 0, np.nan],
+    balance_engine_simple.set_loads(
+        load_position_distance=[150, 200, 0],
+        load_mass=[200, 500, 0],
     )
     balance_engine_simple.solve_adjustment()
     balance_engine_simple.solve_change_state()

--- a/test/core/models/balance/test_span_loads.py
+++ b/test/core/models/balance/test_span_loads.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2026, RTE (http://www.rte-france.com)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+
 import numpy as np
 
 from mechaphlowers.core.models.balance.span_loads import SpanLoads

--- a/test/core/models/balance/test_span_loads.py
+++ b/test/core/models/balance/test_span_loads.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+from mechaphlowers.core.models.balance.span_loads import SpanLoads
+
+
+def test_has_load_on_span__nan() -> None:
+    span_loads = SpanLoads(
+        load_position_distance=[np.nan, 250, np.nan],
+        load_mass=[1000, np.nan, np.nan],
+        span_length=[500, 500, 500, np.nan],
+    )
+
+    np.testing.assert_equal(
+        span_loads.has_load_on_span,
+        np.array([False, False, False]),
+    )

--- a/test/entities/test_section_array.py
+++ b/test/entities/test_section_array.py
@@ -267,8 +267,6 @@ def test_section_array__data_with_optional() -> None:
             "insulator_length": [0.01, 4, 3.2, 0.01],
             "span_length": [1, 500.2, 500.05, np.nan],
             "insulator_mass": [1000.0, 500.0, 500.0, 1000.0],
-            "load_mass": [500, 1000, 500, np.nan],
-            "load_position": [0.2, 0.4, 0.6, np.nan],
             "ground_altitude": [0.0, 3.0, -1, 0],
         }
     )
@@ -296,9 +294,6 @@ def test_section_array__data_with_optional() -> None:
             "insulator_weight": [9810.0, 4905.0, 4905.0, 9810.0],
             "elevation_difference": [2.8, -5.12, 0.12, np.nan],
             "ground_altitude": [0.0, 3.0, -1, 0],
-            "load_mass": [500, 1000, 500, np.nan],
-            "load_weight": [4905.0, 9810.0, 4905.0, np.nan],
-            "load_position": [0.2, 0.4, 0.6, np.nan],
             "bundle_number": [1] * 4,
         },
     )
@@ -322,8 +317,6 @@ def test_section_array__wrong_ground_altitude() -> None:
             "insulator_length": [0.01, 4, 3.2, 0.01],
             "span_length": [1, 500.2, 500.05, np.nan],
             "insulator_mass": [1000.0, 500.0, 500.0, 1000.0],
-            "load_mass": [500, 1000, 500, np.nan],
-            "load_position": [0.2, 0.4, 0.6, np.nan],
             "ground_altitude": [0.0, 7.0, -1, 5],
         }
     )
@@ -349,9 +342,6 @@ def test_section_array__wrong_ground_altitude() -> None:
             "insulator_weight": [9810.0, 4905.0, 4905.0, 9810.0],
             "elevation_difference": [2.8, -5.12, 0.12, np.nan],
             "ground_altitude": [0.0, -25.0, -1.0, -30.0],
-            "load_mass": [500, 1000, 500, np.nan],
-            "load_weight": [4905.0, 9810.0, 4905.0, np.nan],
-            "load_position": [0.2, 0.4, 0.6, np.nan],
             "bundle_number": [1] * 4,
         },
     )

--- a/test/numeric/test_balance_engine_cubic_solver_consistency.py
+++ b/test/numeric/test_balance_engine_cubic_solver_consistency.py
@@ -44,8 +44,6 @@ def _run_balance_engine_with_solver(
                 "insulator_mass": convert_weight_to_mass(
                     [1000, 500, 500, 1000]
                 ),
-                "load_mass": convert_weight_to_mass([0, 1000, 0, np.nan]),
-                "load_position": [0, 0.4, 0, np.nan],
             }
         ),
         sagging_parameter=2000,
@@ -56,6 +54,10 @@ def _run_balance_engine_with_solver(
     engine = BalanceEngine(
         cable_array=cable_array_AM600,
         section_array=section_array,
+    )
+    engine.set_loads(
+        load_position_distance=[0, 120, 0],
+        load_mass=convert_weight_to_mass([0, 1000, 0]),
     )
     engine.solve_adjustment()
     engine.solve_change_state()

--- a/test/plotting/test_plot_loads.py
+++ b/test/plotting/test_plot_loads.py
@@ -36,8 +36,6 @@ def balance_engine_no_loads(cable_array_AM600: CableArray) -> BalanceEngine:
                 "insulator_length": [3, 3, 3, 3],
                 "span_length": [500, 300, 400, np.nan],
                 "insulator_mass": [100, 50, 50, 100],
-                "load_mass": [0, 0, 0, np.nan],
-                "load_position": [0, 0, 0, np.nan],
             }
         ),
         sagging_parameter=2000,
@@ -64,8 +62,6 @@ def balance_engine_with_loads(cable_array_AM600: CableArray) -> BalanceEngine:
                 "insulator_length": [3, 3, 3, 3],
                 "span_length": [500, 300, 400, np.nan],
                 "insulator_mass": [100, 50, 50, 100],
-                "load_mass": [500, 0, 1000, np.nan],
-                "load_position": [0.2, 0.4, 0.6, np.nan],
             }
         ),
         sagging_parameter=2000,
@@ -73,10 +69,16 @@ def balance_engine_with_loads(cable_array_AM600: CableArray) -> BalanceEngine:
     )
     section_array.add_units({"line_angle": "grad"})
 
-    return BalanceEngine(
+    balance_engine = BalanceEngine(
         cable_array=cable_array_AM600,
         section_array=section_array,
     )
+    balance_engine.set_loads(
+        load_position_distance=[100, 150, 240],
+        load_mass=[500, 0, 1000],
+    )
+
+    return balance_engine
 
 
 def test_plot_loads(balance_engine_with_loads: BalanceEngine):
@@ -104,21 +106,11 @@ def test_plot_add_loads_later(balance_engine_no_loads: BalanceEngine):
     balance_engine_no_loads.solve_adjustment()
 
     # Modify loads positions and mass
-    balance_engine_no_loads.section_array._data["load_mass"] = [
-        5000,
-        10000,
-        0,
-        np.nan,
-    ]
-    balance_engine_no_loads.section_array._data["load_position"] = [
-        0.2,
-        0.4,
-        0.7,
-        np.nan,
-    ]
-
-    # Reset objects to factor in modifications
-    balance_engine_no_loads.reset(full=False)
+    balance_engine_no_loads.set_loads(
+        load_position_distance=[100, 120, 280],
+        load_mass=[5000, 10000, 0],
+    )
+    # Reset plot engine to factor in modifications
     plt_engine.reset(balance_engine=balance_engine_no_loads)
 
     balance_engine_no_loads.solve_adjustment()
@@ -158,9 +150,9 @@ def test_plot_add_loads(balance_engine_no_loads: BalanceEngine):
     plt_engine = PlotEngine(balance_engine_no_loads)
 
     # Modify loads positions and mass
-    balance_engine_no_loads.add_loads(
-        load_position_distance=np.array([100, 150, 300, np.nan]),
-        load_mass=[5000, 10000, 0, np.nan],
+    balance_engine_no_loads.set_loads(
+        load_position_distance=np.array([100, 150, 300]),
+        load_mass=[5000, 10000, 0],
     )
 
     # Reset objects to factor in modifications
@@ -217,8 +209,6 @@ def test_get_loads_coords_4_spans(cable_array_AM600: CableArray):
                 "insulator_length": [3, 3, 3, 3, 3],
                 "span_length": [500, 300, 400, 400, np.nan],
                 "insulator_mass": [100, 50, 50, 50, 100],
-                "load_mass": [500, 1000, 0, 0, np.nan],
-                "load_position": [0.2, 0.4, 0.6, 0, np.nan],
             }
         ),
         sagging_parameter=2000,
@@ -230,6 +220,11 @@ def test_get_loads_coords_4_spans(cable_array_AM600: CableArray):
         cable_array=cable_array_AM600,
         section_array=section_array,
     )
+    balance_engine.set_loads(
+        load_position_distance=[100, 150, 240, 0],
+        load_mass=[500, 1000, 0, 0],
+    )
+
     plt_engine = PlotEngine(balance_engine)
     coords_loads_before_solve = plt_engine.get_loads_coords()
     assert coords_loads_before_solve == {}
@@ -264,22 +259,12 @@ def test_get_coords_no_loads(balance_engine_no_loads: BalanceEngine):
 
     balance_engine_no_loads.solve_adjustment()
 
-    # Modify loads positions and mass
-    balance_engine_no_loads.section_array._data["load_mass"] = [
-        5000,
-        10000,
-        0,
-        np.nan,
-    ]
-    balance_engine_no_loads.section_array._data["load_position"] = [
-        0.2,
-        0.4,
-        0.7,
-        np.nan,
-    ]
+    balance_engine_no_loads.set_loads(
+        load_position_distance=[100, 150, 280],
+        load_mass=[5000, 10000, 0],
+    )
 
-    # Reset objects to factor in modifications
-    balance_engine_no_loads.reset(full=False)
+    plt_engine.reset(balance_engine_no_loads)
 
     balance_engine_no_loads.solve_adjustment()
     balance_engine_no_loads.solve_change_state(

--- a/test/plotting/test_plot_reactivty.py
+++ b/test/plotting/test_plot_reactivty.py
@@ -152,9 +152,9 @@ class TestNotificationTriggers:
             "reset",
             wraps=plt_engine.position_engine.reset,
         ) as mock_reset:
-            balance_engine_base_test.add_loads(
-                load_position_distance=np.array([0, 0, 0, np.nan]),
-                load_mass=np.array([0, 0, 0, np.nan]),
+            balance_engine_base_test.set_loads(
+                load_position_distance=np.array([0, 0, 0]),
+                load_mass=np.array([0, 0, 0]),
             )
 
             mock_reset.assert_called_once_with(
@@ -194,9 +194,9 @@ class TestNotificationTriggers:
                 wraps=pe2.position_engine.reset,
             ) as mock2,
         ):
-            balance_engine_base_test.add_loads(
-                load_position_distance=np.array([0, 0, 0, np.nan]),
-                load_mass=np.array([0, 0, 0, np.nan]),
+            balance_engine_base_test.set_loads(
+                load_position_distance=np.array([0, 0, 0]),
+                load_mass=np.array([0, 0, 0]),
             )
 
             mock1.assert_called_once_with(
@@ -216,9 +216,9 @@ class TestNotificationTriggers:
             "reset",
             wraps=plt_engine.coords_calculator.reset,
         ) as mock_reset:
-            balance_engine_base_test.add_loads(
-                load_position_distance=np.array([0, 0, 0, np.nan]),
-                load_mass=np.array([0, 0, 0, np.nan]),
+            balance_engine_base_test.set_loads(
+                load_position_distance=np.array([0, 0, 0]),
+                load_mass=np.array([0, 0, 0]),
             )
 
             mock_reset.assert_called_once()
@@ -280,9 +280,9 @@ class TestReferenceIntegrity:
         plt_engine = PlotEngine(balance_engine_base_test)
         original_id = id(plt_engine.span_model)
 
-        balance_engine_base_test.add_loads(
-            load_position_distance=np.array([0, 0, 0, np.nan]),
-            load_mass=np.array([0, 0, 0, np.nan]),
+        balance_engine_base_test.set_loads(
+            load_position_distance=np.array([0, 0, 0]),
+            load_mass=np.array([0, 0, 0]),
         )
 
         assert id(plt_engine.span_model) == original_id
@@ -381,9 +381,9 @@ class TestCoordCoherence:
         nodes_span_model.get_coords(), proving set_cable_coordinates() was called."""
         plt_engine = PlotEngine(balance_engine_base_test)
 
-        balance_engine_base_test.add_loads(
-            load_position_distance=np.array([0, 0, 0, np.nan]),
-            load_mass=np.array([0, 0, 0, np.nan]),
+        balance_engine_base_test.set_loads(
+            load_position_distance=np.array([0, 0, 0]),
+            load_mass=np.array([0, 0, 0]),
         )
 
         x_expected, _ = plt_engine.span_model.get_coords(
@@ -401,7 +401,7 @@ class TestCoordCoherence:
         1. After construction, x_cable is computed once (initial parameter).
         2. solve_adjustment + solve_change_state update nodes_span_model.parameter
            in-place — but solve does NOT call notify(), so x_cable remains stale.
-        3. add_loads() calls reset(full=False) -> BalanceEngine.notify()
+        3. set_loads() calls reset(full=False) -> BalanceEngine.notify()
            -> PositionEngine.reset() -> coords_calculator.reset() -> set_cable_coordinates()
            recomputes x_cable -> PositionEngine.notify() -> PlotEngine.update().
         4. x_cable now matches the post-solve parameter and differs from
@@ -420,10 +420,10 @@ class TestCoordCoherence:
             plt_engine.coords_calculator.x_cable, x_cable_initial
         )
 
-        # Trigger the observer chain via add_loads.
-        balance_engine_base_test.add_loads(
-            load_position_distance=np.array([0, 0, 0, np.nan]),
-            load_mass=np.array([0, 0, 0, np.nan]),
+        # Trigger the observer chain via set_loads.
+        balance_engine_base_test.set_loads(
+            load_position_distance=np.array([0, 0, 0]),
+            load_mass=np.array([0, 0, 0]),
         )
 
         # x_cable is now consistent with the (post-solve) span model.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
cf. #426 

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**Migration guide**

`add_loads` is deprecated (although it still works). Use `set_loads` instead. Also, the new method expects arguments with a different length. The expected length is now the number of spans. The expected length fot the arguments of `add_loads` remains unchanged (number of pylons).

Examples:
```python
# Before
study.add_loads(
    load_position_distance=np.array([150, 200, 0, np.nan]),
    load_mass=np.array([500, 70, 0, np.nan]),
)

# After
study.set_loads(
    load_position_distance=np.array([150, 200, 0]),
    load_mass=np.array([500, 70, 0]),
)

# Before
balance_engine.add_loads(
    load_position_distance=np.array([150, 200, 0, np.nan]),
    load_mass=np.array([500, 70, 0, np.nan]),
)

# After
balance_engine.set_loads(
    load_position_distance=np.array([150, 200, 0]),
    load_mass=np.array([500, 70, 0]),
)
```

NB: The new methods `SpanLoads.__init__` and `SpanLoads.set_loads` expect several arguments with different lengths: the length of `load_position_distance` and `load_mass` must be the number of spans; the length of `span_length` must be the number of pylons (counter-intuitive but it's the same as `SectionArray.data.span_length`).