### PR TITLE
chore,feat: Update thermohl and use np.datetime64 for datetimes

### DIFF
--- a/docs/user_guide/ug_thermal_engine.md
+++ b/docs/user_guide/ug_thermal_engine.md
@@ -13,7 +13,7 @@ The ThermalEngine computes the temperature distribution in power transmission ca
 - Cable properties (resistance, thermal conductivity, dimensions)
 - Operational parameters (electrical current)
 - Environmental conditions (ambient temperature, wind speed, wind angle, solar radiation)
-- Geographic location and time (latitude, longitude, altitude, month, day, hour)
+- Geographic location and time (latitude, longitude, altitude, datetime)
 
 ### Thermal Calculations Supported
 
@@ -50,9 +50,9 @@ thermal_engine.set(
     longitude=np.array([0.0]),
     altitude=np.array([0.0]),
     azimuth=np.array([0.0]),  # Cable direction (degrees from north)
-    month=np.array([3]),
-    day=np.array([21]),
-    hour=np.array([12]),
+    datetime_utc=np.array([
+        np.datetime64(f"2026-3-21T12:00"),
+    ]),
     intensity=np.array([500.0]),  # Current in Amperes
     ambient_temp=np.array([15.0]),  # Ambient temperature in Celsius
     wind_speed=np.array([10.0]),  # Wind speed in m/s
@@ -71,9 +71,7 @@ thermal_engine.set(
 | `longitude` | np.ndarray | degrees | Geographic longitude |
 | `altitude` | np.ndarray | meters | Altitude above sea level |
 | `azimuth` | np.ndarray | degrees | Cable direction (0°=North, 90°=East, 180°=South, 270°=West) |
-| `month` | np.ndarray | 1-12 | Month of the year |
-| `day` | np.ndarray | 1-31 | Day of the month |
-| `hour` | np.ndarray | 0-23 | Hour of the day |
+| `datetime_utc` | np.ndarray | - | Datetime (np.datetime64) in UTC. Year is indifferent, feel free to set an arbitrary value. |
 | `intensity` | np.ndarray | Amperes | Electrical current through the cable |
 | `ambient_temp` | np.ndarray | °C | Ambient air temperature |
 | `wind_speed` | np.ndarray | m/s | Wind speed magnitude |
@@ -94,9 +92,7 @@ thermal_engine.set(
     longitude=np.array([0.0]),
     altitude=np.array([0.0]),
     azimuth=np.array([0.0]),
-    month=np.array([3]),
-    day=np.array([21]),
-    hour=np.array([12]),
+    datetime_utc=np.array([np.datetime64(f"2026-03-21T12:00")]),
     intensity=np.array([500.0]),
     ambient_temp=np.array([15.0]),
     wind_speed=np.array([10.0]),
@@ -121,9 +117,11 @@ thermal_engine.set(
     longitude=np.array([0.0, 1.0, 2.0]),
     altitude=np.array([0.0, 100.0, 200.0]),
     azimuth=np.array([0.0, 0.0, 90.0]),
-    month=np.array([3, 3, 3]),
-    day=np.array([21, 21, 21]),
-    hour=np.array([12, 12, 12]),
+    datetime_utc=np.array([
+        np.datetime64(f"2026-03-21T12:00"),
+        np.datetime64(f"2026-03-21T12:00"),
+        np.datetime64(f"2026-03-21T12:00"),
+    ]),
     intensity=np.array([500.0, 600.0, 700.0]),
     ambient_temp=np.array([15.0, 18.0, 20.0]),
     wind_speed=np.array([10.0, 5.0, 15.0]),
@@ -224,9 +222,10 @@ thermal_engine.set(
     longitude=np.array([0.0, 1.0]),
     altitude=np.array([0.0, 100.0]),
     azimuth=np.array([0.0, 45.0]),
-    month=np.array([3, 3]),
-    day=np.array([21, 21]),
-    hour=np.array([12, 14]),
+    datetime_utc=np.array([
+        np.datetime64(f"2026-3-21T12:00"),
+        np.datetime64(f"2026-3-21T14:00"),
+    ]),
     intensity=np.array([500.0, 600.0]),
     ambient_temp=np.array([15.0, 18.0]),
     wind_speed=np.array([10.0, 8.0]),

--- a/docs/user_guide/ug_thermal_engine.md
+++ b/docs/user_guide/ug_thermal_engine.md
@@ -51,7 +51,7 @@ thermal_engine.set(
     altitude=np.array([0.0]),
     azimuth=np.array([0.0]),  # Cable direction (degrees from north)
     datetime_utc=np.array([
-        np.datetime64(f"2026-3-21T12:00"),
+        np.datetime64("2026-03-21T12:00"),
     ]),
     intensity=np.array([500.0]),  # Current in Amperes
     ambient_temp=np.array([15.0]),  # Ambient temperature in Celsius
@@ -92,7 +92,7 @@ thermal_engine.set(
     longitude=np.array([0.0]),
     altitude=np.array([0.0]),
     azimuth=np.array([0.0]),
-    datetime_utc=np.array([np.datetime64(f"2026-03-21T12:00")]),
+    datetime_utc=np.array([np.datetime64("2026-03-21T12:00")]),
     intensity=np.array([500.0]),
     ambient_temp=np.array([15.0]),
     wind_speed=np.array([10.0]),
@@ -118,14 +118,15 @@ thermal_engine.set(
     altitude=np.array([0.0, 100.0, 200.0]),
     azimuth=np.array([0.0, 0.0, 90.0]),
     datetime_utc=np.array([
-        np.datetime64(f"2026-03-21T12:00"),
-        np.datetime64(f"2026-03-21T12:00"),
-        np.datetime64(f"2026-03-21T12:00"),
+        np.datetime64("2026-03-21T12:00"),
+        np.datetime64("2026-03-21T12:00"),
+        np.datetime64("2026-03-21T12:00"),
     ]),
     intensity=np.array([500.0, 600.0, 700.0]),
     ambient_temp=np.array([15.0, 18.0, 20.0]),
     wind_speed=np.array([10.0, 5.0, 15.0]),
     wind_angle=np.array([90.0, 90.0, 90.0]),
+    nebulosity=np.array([0, 0, 0]),
 )
 
 result = thermal_engine.steady_temperature()
@@ -151,9 +152,14 @@ print(result.data)
 
 **Output columns:**
 
-- `t_avg`: Average cable temperature
-- `t_surf`: Surface temperature
-- `t_core`: Core temperature (highest temperature in the conductor)
+- `average_temperature`: Average cable temperature
+- `surface_temperature`: Surface temperature
+- `core_temperature`: Core temperature (highest temperature in the conductor)
+- `joule_power`
+- `solar_power`
+- `convection_power`
+- `radiation_power`
+- `precipitation_power`
 
 ### 4. Steady-State Intensity Calculation
 
@@ -191,9 +197,9 @@ print(result.data)
 
 - `time`: Time step
 - `id`: Cable/condition ID
-- `t_avg`: Average temperature at that time
-- `t_surf`: Surface temperature at that time
-- `t_core`: Core temperature at that time
+- `average_temperature`: Average temperature at that time
+- `surface_temperature`: Surface temperature at that time
+- `core_temperature`: Core temperature at that time
 
 **Customize the forecast:**
 
@@ -223,8 +229,8 @@ thermal_engine.set(
     altitude=np.array([0.0, 100.0]),
     azimuth=np.array([0.0, 45.0]),
     datetime_utc=np.array([
-        np.datetime64(f"2026-3-21T12:00"),
-        np.datetime64(f"2026-3-21T14:00"),
+        np.datetime64("2026-03-21T12:00"),
+        np.datetime64("2026-03-21T14:00"),
     ]),
     intensity=np.array([500.0, 600.0]),
     ambient_temp=np.array([15.0, 18.0]),
@@ -233,8 +239,8 @@ thermal_engine.set(
 )
 
 # Update specific parameters (must be numpy arrays of same length)
-thermal_engine.dict_input["I"] = np.array([700.0, 800.0])  # Change intensity
-thermal_engine.dict_input["Ta"] = np.array([20.0, 22.0])  # Change ambient temperature
+thermal_engine.dict_input["transit"] = np.array([700.0, 800.0])  # Change intensity
+thermal_engine.dict_input["ambient_temperature"] = np.array([20.0, 22.0])  # Change ambient temperature
 thermal_engine.load()  # Reload with new parameters
 
 # Compute new results
@@ -282,11 +288,11 @@ print(f"Number of conditions: {len(thermal_engine)}")
 
 ### Temperature Output Interpretation
 
-- **t_core**: Highest temperature in the conductor (most critical)
-- **t_surf**: Temperature at cable surface
-- **t_avg**: Average temperature across the conductor
+- **core_temperature**: Highest temperature in the conductor (most critical)
+- **surface_temperature**: Temperature at cable surface
+- **average_temperature**: Average temperature across the conductor
 
-Typically: `t_core > t_avg > t_surf`
+Typically: `core_temperature > average_temperature > surface_temperature`
 
 ### Wind Angle Conventions
 
@@ -316,4 +322,3 @@ Not yet implemented:
 - Visualization tools
 
 See the code comments for planned improvements.
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "plotly<=5.24.1",
     "pyyaml==6.0.2",
     "pint==0.25",
-    "thermohl==1.7.0",
+    "thermohl==1.8.0",
     "xxhash==3.5.0",
     "pydantic==2.10.6",
 ]

--- a/src/mechaphlowers/core/models/cable/thermal.py
+++ b/src/mechaphlowers/core/models/cable/thermal.py
@@ -179,7 +179,7 @@ def check_inputs(
     """Validate input parameters.
 
     Ensures all inputs are numpy arrays with the same size. Also ensures that
-    nebulositues are in the right range.
+    nebulosities are in the right range.
 
     Args:
         nebulosity(np.array): Nebulosity (array of int between 0 and 8).
@@ -194,8 +194,6 @@ def check_inputs(
         ValueError: If array inputs have incompatible sizes.
         TypeError: If any input is not a numpy array.
     """
-    check_nebulosity_range(nebulosity)
-
     kwargs["nebulosity"] = nebulosity
 
     array_length: int = nebulosity.size
@@ -212,6 +210,8 @@ def check_inputs(
                 f"All array inputs must have the same length. "
                 f"Expected {array_length}, got {value.size} for {key}."
             )
+
+    check_nebulosity_range(nebulosity)
 
     return kwargs, array_length
 

--- a/src/mechaphlowers/core/models/cable/thermal.py
+++ b/src/mechaphlowers/core/models/cable/thermal.py
@@ -6,12 +6,11 @@
 
 import logging
 from abc import ABC, abstractmethod
-from datetime import datetime
-from math import floor
 from typing import Any
 
 import numpy as np
 import pandas as pd
+from numpy import typing as npt
 from thermohl import solver  # type: ignore
 from typing_extensions import Self
 
@@ -172,22 +171,18 @@ class ThermalForecastArray:
 
 
 def check_inputs(
-    month: np.ndarray[Any, np.dtype[np.integer]] | None = None,
-    day: np.ndarray[Any, np.dtype[np.integer]] | None = None,
-    hour: np.ndarray[Any, np.dtype[np.integer] | np.dtype[np.floating]]
-    | None = None,
-    datetime_utc: list[datetime] | None = None,
-    nebulosity: np.ndarray[Any, np.dtype[np.integer] | np.dtype[np.floating]]
-    | None = None,
-    **kwargs: np.ndarray[Any, Any] | list[datetime],
-) -> tuple[dict[str, np.ndarray[Any, Any] | list[datetime]], int]:
+    nebulosity: np.ndarray[Any, np.dtype[np.integer] | np.dtype[np.floating]],
+    **kwargs: npt.NDArray[np.integer | np.floating | np.datetime64],
+) -> tuple[
+    dict[str, npt.NDArray[np.integer | np.floating | np.datetime64]], int
+]:
     """Validate input parameters.
 
-    Ensures all inputs are numpy arrays with the same size and that
-    datetime-related inputs have the right type. Also ensures that
-    month, day and hour, if given, are in the right range.
+    Ensures all inputs are numpy arrays with the same size. Also ensures that
+    nebulositues are in the right range.
 
     Args:
+        nebulosity(np.array): Nebulosity (array of int between 0 and 8).
         **kwargs: Input parameters as numpy arrays.
 
     Returns:
@@ -199,11 +194,11 @@ def check_inputs(
         ValueError: If array inputs have incompatible sizes.
         TypeError: If any input is not a numpy array.
     """
+    check_nebulosity_range(nebulosity)
 
-    array_length: int | None = None
+    kwargs["nebulosity"] = nebulosity
 
-    if nebulosity is not None:
-        kwargs["nebulosity"] = nebulosity
+    array_length: int = nebulosity.size
 
     for key, value in kwargs.items():
         if not isinstance(value, np.ndarray):
@@ -212,170 +207,22 @@ def check_inputs(
             )
 
         # Track and validate the length of array inputs
-        if array_length is None:
-            array_length = value.size
-        elif value.size != array_length:
+        if value.size != array_length:
             raise ValueError(
                 f"All array inputs must have the same length. "
                 f"Expected {array_length}, got {value.size} for {key}."
             )
 
-    array_length = check_datetime_arguments(
-        array_length,
-        month=month,
-        day=day,
-        hour=hour,
-        datetime_utc=datetime_utc,
-    )
-
-    check_nebulosity_range(nebulosity)
-
-    if month is not None:
-        kwargs["month"] = month
-    if day is not None:
-        kwargs["day"] = day
-    if hour is not None:
-        kwargs["hour"] = hour
-    if datetime_utc is not None:
-        kwargs["datetime_utc"] = datetime_utc
-
     return kwargs, array_length
 
 
-def check_nebulosity_range(nebulosity: np.ndarray | None = None) -> None:
-    if nebulosity is not None and not np.all(
+def check_nebulosity_range(nebulosity: np.ndarray) -> None:
+    if not np.all(
         ((0 <= nebulosity) & (nebulosity <= 8)) | np.isnan(nebulosity)
     ):
         raise ValueError(
             "Nebulosity values must be in the range [0-8]. Invalid values found in 'nebulosity'."
         )
-
-
-def check_datetime_arguments(  # NOSONAR
-    array_length: int | None,
-    month: np.ndarray[Any, np.dtype[np.integer]] | None,
-    day: np.ndarray[Any, np.dtype[np.integer]] | None,
-    hour: np.ndarray[Any, np.dtype[np.integer | np.floating]] | None,
-    datetime_utc: list[datetime] | None,
-) -> int:
-    if datetime_utc is not None and (
-        month is not None or day is not None or hour is not None
-    ):
-        raise ValueError(
-            "Cannot provide both 'datetime_utc' and individual 'month', 'day', or 'hour' arrays."
-        )
-
-    check_datetime_argument_types(month, day, hour, datetime_utc)
-
-    for arg_name, value in [("month", month), ("day", day), ("hour", hour)]:
-        if value is not None:
-            if not isinstance(value, np.ndarray):
-                raise TypeError(
-                    f"Expected numpy array for '{arg_name}', got {type(value).__name__}."
-                )
-
-            if array_length is None:
-                array_length = value.size
-            elif value.size != array_length:
-                raise ValueError(
-                    f"All array inputs must have the same length. "
-                    f"Expected {array_length}, got {value.size} for {arg_name}."
-                )
-    if datetime_utc is not None:
-        if array_length is None:
-            array_length = len(datetime_utc)
-        elif len(datetime_utc) != array_length:
-            raise ValueError(
-                f"All array inputs must have the same length. "
-                f"Expected {array_length}, got {len(datetime_utc)} for 'datetime_utc'."
-            )
-
-    check_datetime_argument_ranges(
-        month=month,
-        day=day,
-        hour=hour,
-    )
-
-    if array_length is None:
-        array_length = 0
-
-    return array_length
-
-
-def check_datetime_argument_types(
-    month: np.ndarray[Any, np.dtype[np.integer]] | None,
-    day: np.ndarray[Any, np.dtype[np.integer]] | None,
-    hour: np.ndarray[Any, np.dtype[np.integer | np.floating]] | None,
-    datetime_utc: list[datetime] | None,
-) -> None:
-    for arg_name, value in [("month", month), ("day", day), ("hour", hour)]:
-        if value is not None and not isinstance(value, np.ndarray):
-            raise TypeError(
-                f"Expected numpy array for '{arg_name}', got {type(value).__name__}."
-            )
-    for arg_name, value in [("month", month), ("day", day)]:
-        if value is not None and not np.issubdtype(value.dtype, np.integer):
-            raise TypeError(
-                f"Expected integer array for '{arg_name}', got {value.dtype}."
-            )
-
-    if hour is not None and not (
-        np.issubdtype(hour.dtype, np.integer)
-        or np.issubdtype(hour.dtype, np.floating)
-    ):
-        raise TypeError(
-            f"Expected integer or float array for 'hour', got {hour.dtype}."
-        )
-
-    if datetime_utc is not None and not isinstance(datetime_utc, list):
-        raise TypeError(
-            f"Expected list of datetime objects for 'datetime_utc', got {type(datetime_utc).__name__}."
-        )
-
-
-def check_datetime_argument_ranges(
-    month: np.ndarray[Any, np.dtype[np.integer]] | None,
-    day: np.ndarray[Any, np.dtype[np.integer]] | None,
-    hour: np.ndarray[Any, np.dtype[np.integer | np.floating]] | None,
-) -> None:
-    if month is not None and not np.all((1 <= month) & (month <= 12)):
-        raise ValueError(
-            "Month values must be in the range 1-12. Invalid values found in 'month'."
-        )
-    if day is not None and not np.all((1 <= day) & (day <= 31)):
-        raise ValueError(
-            "Day values must be in the range 1-31. Invalid values found in 'day'."
-        )
-    if hour is not None and not np.all((0 <= hour) & (hour < 24)):
-        raise ValueError(
-            "Hour values must be in the range [0-24[. Invalid values found in 'hour'."
-        )
-
-
-def to_datetime(
-    month: np.integer,
-    day: np.integer,
-    hour: np.floating,
-) -> datetime:
-    """Convert month, day, hour to a datetime object.
-
-    Args:
-        month (np.integer): Month value ([1-12]).
-        day (np.integer): Day value ([1-31]).
-        hour (np.floating): Hour value ([0-24[). Can include non-integer hours (e.g. 14.5 for 2:30 PM).
-
-    Returns:
-        datetime: A datetime object representing the given month, day, and hour.
-    """
-    return datetime(
-        1970,  # Arbitrary year since it's not used in calculations
-        month,
-        day,
-        hour=floor(hour),
-        minute=floor((hour % 1) * 60),
-        second=floor(((hour % 1) * 60) % 1 * 60),
-        microsecond=floor((((hour % 1) * 60) % 1 * 60) % 1 * 1000000),
-    )
 
 
 class ThermalEngine:
@@ -412,9 +259,7 @@ class ThermalEngine:
         longitude: np.ndarray,
         altitude: np.ndarray,
         azimuth: np.ndarray,
-        month: np.ndarray,
-        day: np.ndarray,
-        hour: np.ndarray,
+        datetime_utc: npt.NDArray[np.datetime64],
         intensity: np.ndarray,
         ambient_temp: np.ndarray,
         wind_speed: np.ndarray,
@@ -430,14 +275,12 @@ class ThermalEngine:
             longitude (np.ndarray): Longitude values.
             altitude (np.ndarray): Altitude values.
             azimuth (np.ndarray): Azimuth values.
-            month (np.ndarray): Month values.
-            day (np.ndarray): Day values.
-            hour (np.ndarray): Hour values.
+            datetime_utc (np.ndarray): Datetime (year is indifferent).
             intensity (np.ndarray): Current intensity values.
             ambient_temp (np.ndarray): Ambient temperature values.
             wind_speed (np.ndarray): Wind speed values in m/s
             wind_angle (np.ndarray): Wind angle values in degrees, clockwise from North.
-            nebulosity (np.ndarray): Nebulosity level (int from 0 to 8).
+            nebulosity (np.ndarray): Nebulosity level (ints from 0 to 8). 8 is the most clouded.
             solar_irradiance (np.ndarray | None): Solar irradiance values (optional). Defaults to None.
         """
         # Handle optional solar_irradiance - create NaN array if not provided
@@ -450,9 +293,7 @@ class ThermalEngine:
             longitude=longitude,
             altitude=altitude,
             azimuth=azimuth,
-            month=month,
-            day=day,
-            hour=hour,
+            datetime_utc=datetime_utc,
             intensity=intensity,
             ambient_temp=ambient_temp,
             wind_speed=wind_speed,
@@ -461,23 +302,13 @@ class ThermalEngine:
             solar_irradiance=solar_irradiance,
         )
 
-        if inputs.get("datetime_utc") is None:
-            datetime_utc = [
-                to_datetime(month, day, hour)
-                for month, day, hour in zip(
-                    inputs["month"], inputs["day"], inputs["hour"]
-                )
-            ]
-        else:
-            datetime_utc = inputs.get("datetime_utc")  # type: ignore
-
         self.dict_input = {
             "measured_global_radiation": inputs["solar_irradiance"],
             "latitude": inputs["latitude"],
             "longitude": inputs["longitude"],
             "altitude": inputs["altitude"],
             "cable_azimuth": inputs["azimuth"],
-            "datetime_utc": datetime_utc,
+            "datetime_utc": inputs["datetime_utc"],
             "ambient_temperature": inputs["ambient_temp"],
             "wind_speed": inputs["wind_speed"],  # wind speed (m.s**-1)
             "wind_azimuth": inputs[

--- a/test/core/models/cable/test_thermal.py
+++ b/test/core/models/cable/test_thermal.py
@@ -5,8 +5,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 
-from datetime import datetime
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -14,7 +12,6 @@ import pytest
 from mechaphlowers.core.models.cable.thermal import (
     ThermalEngine,
     ThermalTransientResults,
-    to_datetime,
 )
 from mechaphlowers.entities.arrays import CableArray
 from mechaphlowers.entities.errors import UncertaintyNotAvailable
@@ -30,25 +27,11 @@ def thermal_engine_3_spans(cable_array_AM600: CableArray) -> ThermalEngine:
         longitude=np.array([0.0, 0.0, 0.0]),
         altitude=np.array([0.0, 0.0, 0.0]),
         azimuth=np.array([0.0, 0.0, 90.0]),
-        month=np.array(
+        datetime_utc=np.array(
             [
-                3,
-                3,
-                3,
-            ]
-        ),
-        day=np.array(
-            [
-                21,
-                21,
-                21,
-            ]
-        ),
-        hour=np.array(
-            [
-                22,
-                22,
-                12,
+                np.datetime64("2026-03-21T22:00"),
+                np.datetime64("2026-03-21T22:00"),
+                np.datetime64("2026-03-21T12:00"),
             ]
         ),
         intensity=np.array([100.0, 1000.0, 1000.0]),
@@ -76,22 +59,10 @@ def test_thermohl_cable_temp_arrays(cable_array_AM600: CableArray):
         longitude=np.array([0.0, 0.0]),
         altitude=np.array([0.0, 0.0]),
         azimuth=np.array([0.0, 0.0]),
-        month=np.array(
+        datetime_utc=np.array(
             [
-                3,
-                3,
-            ]
-        ),
-        day=np.array(
-            [
-                21,
-                21,
-            ]
-        ),
-        hour=np.array(
-            [
-                12,
-                12,
+                np.datetime64("2026-03-21T12:00"),
+                np.datetime64("2026-03-21T12:00"),
             ]
         ),
         intensity=np.array([100.0, 100.0]),
@@ -114,22 +85,10 @@ def test_thermohl_cable_temp_arrays(cable_array_AM600: CableArray):
         longitude=np.array([0.0, 0.0]),
         altitude=np.array([0.0, 0.0]),
         azimuth=np.array([0.0, 0.0]),
-        month=np.array(
+        datetime_utc=np.array(
             [
-                3,
-                3,
-            ]
-        ),
-        day=np.array(
-            [
-                21,
-                21,
-            ]
-        ),
-        hour=np.array(
-            [
-                12,
-                12,
+                np.datetime64("2026-03-21T12:00"),
+                np.datetime64("2026-03-21T12:00"),
             ]
         ),
         intensity=np.array([100.0, 100.0]),
@@ -245,24 +204,11 @@ def test_wrong_array_length(cable_array_AM600: CableArray):
             longitude=np.array([0.0, 0.0]),
             altitude=np.array([0.0, 0.0]),
             azimuth=np.array([0.0, 0.0]),
-            month=np.array(
+            datetime_utc=np.array(
                 [
-                    3,
-                    3,
-                    3,
-                ]
-            ),
-            day=np.array(
-                [
-                    21,
-                    21,
-                ]
-            ),
-            hour=np.array(
-                [
-                    12,
-                    12,
-                    12,
+                    np.datetime64("2026-03-21T12:00"),
+                    np.datetime64("2026-03-21T12:00"),
+                    np.datetime64("2026-03-21T12:00"),
                 ]
             ),
             intensity=np.array([100.0, 100.0]),
@@ -286,53 +232,6 @@ def test_wrong_array_length_at_load(thermal_engine_3_spans: ThermalEngine):
     ):
         thermal_engine.dict_input["latitude"] = np.array([45.0, 45.0])
         thermal_engine.load()
-
-
-def test_wrong_array_length_datetime(
-    thermal_engine_3_spans: ThermalEngine,
-):
-    thermal_engine = thermal_engine_3_spans
-
-    thermal_engine.dict_input["datetime_utc"] = [
-        datetime(2024, 3, 21, 12),
-        datetime(2024, 3, 21, 12),
-    ]
-    with pytest.raises(
-        ValueError,
-        match="All array inputs must have the same length. Expected 3, got 2 for 'datetime_utc'.",
-    ):
-        thermal_engine.load()
-
-
-def test_wrong_type_month(thermal_engine_3_spans: ThermalEngine):
-    thermal_engine = thermal_engine_3_spans
-
-    with pytest.raises(
-        TypeError,
-        match="Expected integer array for 'month', got float64.",
-    ):
-        del thermal_engine.dict_input["datetime_utc"]
-        thermal_engine.dict_input["month"] = np.array([3.0, 3.0, 3.0])
-        thermal_engine.dict_input["day"] = np.array([21, 21, 21])
-        thermal_engine.load()
-
-
-def test_wrong_type_day(thermal_engine_3_spans: ThermalEngine):
-    thermal_engine = thermal_engine_3_spans
-
-    with pytest.raises(
-        TypeError,
-        match="Expected integer array for 'day', got float64.",
-    ):
-        del thermal_engine.dict_input["datetime_utc"]
-        thermal_engine.dict_input["month"] = np.array([3, 3, 3])
-        thermal_engine.dict_input["day"] = np.array([21.0, 21.0, 21.0])
-        thermal_engine.load()
-
-
-def test_to_datetime():
-    result = to_datetime(3, 31, 16 + 42 / 60 + 3.1234567 / 3600)
-    assert result == datetime(1970, 3, 31, 16, 42, 3, 123456)
 
 
 def test_add_manual_value_and_load(thermal_engine_3_spans: ThermalEngine):
@@ -376,25 +275,11 @@ def test_transient_thermal(cable_array_AM600: CableArray):
         longitude=np.array([0.0, 0.0, 0.0]),
         altitude=np.array([0.0, 0.0, 0.0]),
         azimuth=np.array([0.0, 0.0, 20.0]),
-        month=np.array(
+        datetime_utc=np.array(
             [
-                3,
-                3,
-                3,
-            ]
-        ),
-        day=np.array(
-            [
-                21,
-                21,
-                21,
-            ]
-        ),
-        hour=np.array(
-            [
-                12,
-                12,
-                12,
+                np.datetime64("2026-03-21T12:00"),
+                np.datetime64("2026-03-21T12:00"),
+                np.datetime64("2026-03-21T12:00"),
             ]
         ),
         intensity=np.array([100.0, 100.0, 100.0]),
@@ -425,25 +310,11 @@ def test_nebulosity_variation(cable_array_AM600: CableArray):
         longitude=np.array([0.0, 0.0, 0.0]),
         altitude=np.array([0.0, 0.0, 0.0]),
         azimuth=np.array([0.0, 0.0, 0.0]),
-        month=np.array(
+        datetime_utc=np.array(
             [
-                3,
-                3,
-                3,
-            ]
-        ),
-        day=np.array(
-            [
-                21,
-                21,
-                21,
-            ]
-        ),
-        hour=np.array(
-            [
-                12,
-                12,
-                12,
+                np.datetime64("2026-03-21T12:00"),
+                np.datetime64("2026-03-21T12:00"),
+                np.datetime64("2026-03-21T12:00"),
             ]
         ),
         intensity=np.array([100.0, 100.0, 100.0]),

--- a/uv.lock
+++ b/uv.lock
@@ -853,7 +853,7 @@ requires-dist = [
     { name = "pyyaml", specifier = "==6.0.2" },
     { name = "requests", marker = "extra == 'full'", specifier = "==2.33.1" },
     { name = "scipy", marker = "extra == 'full'", specifier = "<=1.14.1" },
-    { name = "thermohl", specifier = "==1.7.0" },
+    { name = "thermohl", specifier = "==1.8.0" },
     { name = "xxhash", specifier = "==3.5.0" },
 ]
 provides-extras = ["full"]
@@ -1967,16 +1967,16 @@ wheels = [
 
 [[package]]
 name = "thermohl"
-version = "1.7.0"
+version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/61/e9a4b5e5b373a5a03f56f8230bb37c6d0541d9d6b99809b775e3b7942765/thermohl-1.7.0.tar.gz", hash = "sha256:019132e5cdeab59736bb16bbc7436029c87520cb0ee86e16f5d70be5f8d3c08e", size = 1071375, upload-time = "2026-06-04T09:02:44.297Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/23/125a47b53b1098f4ed4d28a89d414da32441898d85f73cb54c210e93303e/thermohl-1.8.0.tar.gz", hash = "sha256:af27191b7ca892937281d422d6903432e01c7d33c9b6813ee39dacdd71ac62ac", size = 1072487, upload-time = "2026-06-15T12:21:11.045Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/7d/5125e9bf673185326c0ef0fdfc636dc0dbd7d715f4080cb12bc7786341be/thermohl-1.7.0-py3-none-any.whl", hash = "sha256:ac905d19d465a40678496e38e06376f742c8b1d5709be50deba6c3c2d851e32c", size = 77461, upload-time = "2026-06-04T09:02:42.741Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/11/bfcb002c9a3f1f50a3e1e52b11d9bc64ab94898c6eb66e479665594ca24f/thermohl-1.8.0-py3-none-any.whl", hash = "sha256:b8c38660b6f6209c9add9a2b72e1565c580b08d4ba612c3ad84d681d02fee08a", size = 77922, upload-time = "2026-06-15T12:21:09.864Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Update thermohl 1.7.0 -> 1.8.0 (see [release notes](https://github.com/phlowers/thermohl/releases/tag/v1.8.0))
- Adapt code: in thermohl datetimes are now represented as np.datetime64 instead of datetime.datetime.
- `ThermalEngine.set` now expects a `datetime_utc` argument which is an array of `np.datetime64` instead of a list of `datetime.datetime`. Former `month`, `day`, `hour` arguments are removed. This improves performance and makes it possible to remove some amount of unnecessary complex code.

Thi PR also prepares for https://github.com/phlowers/phlowers-stellar-app/issues/766, https://github.com/phlowers/phlowers-stellar-app/issues/765 and https://github.com/phlowers/phlowers-stellar-app/issues/764.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
ThermalEngine.set now expects a datetime_utc argument which is an array of np.datetime64. Former month, day and hour arguments are removed. Adapt calls to this method:
```python
# Before
thermal_engine.set(
    month=np.array([3, 3]),
    day=np.array([21, 21]),
    hour=np.array([22, 22]),
    ...
)

# After
thermal_engine.set(
    datetime_utc=np.array(
        [
            np.datetime64("2026-03-21T22:00"),
            np.datetime64("2026-03-21T22:00"),
        ]
    ),
    ...
)
```
NB: The year is indifferent, feel free to use an arbitrary value.