### PR TITLE
feat(#457): Improve handling of input data in thermal computations

### DIFF
--- a/src/mechaphlowers/core/models/cable/thermal.py
+++ b/src/mechaphlowers/core/models/cable/thermal.py
@@ -24,8 +24,17 @@ logger = logging.getLogger(__name__)
 class ThermalResults(ABC):
     """Thermal results base class."""
 
-    def __init__(self, input_data: dict | pd.DataFrame):
-        self.data = self.parse_results(input_data)
+    INPUT_PREFIX = "input_"
+
+    def __init__(
+        self,
+        input_data: dict | pd.DataFrame,
+        return_inputs: bool = True,
+    ):
+        results = self.parse_results(input_data)
+        inputs = self._pop_inputs(results)  # noqa: S2259
+        self.inputs = inputs if return_inputs else None
+        self.data = results
 
     @staticmethod
     @abstractmethod
@@ -53,17 +62,35 @@ class ThermalResults(ABC):
         class_name = type(self).__name__
         return f"{class_name}\n{self.__str__()}"
 
+    @classmethod
+    def _input_columns(cls, df: pd.DataFrame) -> list[str]:
+        return [
+            column
+            for column in df.columns
+            if column.startswith(cls.INPUT_PREFIX)
+        ]
+
+    @classmethod
+    def _pop_inputs(cls, df: pd.DataFrame) -> pd.DataFrame:
+        input_columns = cls._input_columns(df)
+        inputs = df[input_columns]
+        df.drop(columns=input_columns, inplace=True)
+        inputs.rename(
+            columns=lambda s: s.replace(cls.INPUT_PREFIX, ""), inplace=True
+        )
+        return inputs
+
 
 class ThermalTransientResults(ThermalResults):
     """Thermal transient results class for transient temperature calculations."""
 
-    def __init__(self, input_data: dict | pd.DataFrame):
+    def __init__(self, input_data: dict | pd.DataFrame, *args, **kwargs):
         """Initialize transient thermal results.
 
         Args:
             input_data (dict | pd.DataFrame): Raw transient thermal results data.
         """
-        super().__init__(input_data)
+        super().__init__(input_data, *args, **kwargs)
 
     @staticmethod
     def parse_results(data: dict | pd.DataFrame) -> pd.DataFrame:
@@ -103,13 +130,13 @@ class ThermalTransientResults(ThermalResults):
 class ThermalSteadyResults(ThermalResults):
     """Thermal steady-state results parser."""
 
-    def __init__(self, input_data: dict | pd.DataFrame):
+    def __init__(self, input_data: dict | pd.DataFrame, *args, **kwargs):
         """Initialize steady-state thermal results.
 
         Args:
             input_data (dict | pd.DataFrame): Raw steady-state thermal results data.
         """
-        super().__init__(input_data)
+        super().__init__(input_data, *args, **kwargs)
 
     @staticmethod
     def parse_results(
@@ -546,6 +573,7 @@ class ThermalEngine:
         self,
         intensity: np.ndarray | None = None,
         return_uncertainty: bool = False,
+        return_inputs: bool = True,
     ) -> SteadyTemperatureResults:
         """Compute steady-state temperature results.
 
@@ -558,12 +586,15 @@ class ThermalEngine:
             self.load()
         return SteadyTemperatureResults(
             self.thermal_model.steady_temperature(
-                return_uncertainty=return_uncertainty
-            )
+                return_uncertainty=return_uncertainty,
+            ),
+            return_inputs=return_inputs,
         )
 
     def steady_intensity(
-        self, target_temperature: np.ndarray | None = None
+        self,
+        target_temperature: np.ndarray | None = None,
+        return_inputs: bool = True,
     ) -> SteadyIntensityResults:
         """Compute steady-state intensity results.
 
@@ -574,11 +605,16 @@ class ThermalEngine:
             self.target_temperature = target_temperature
 
         return SteadyIntensityResults(
-            self.thermal_model.steady_intensity(self.target_temperature)
+            self.thermal_model.steady_intensity(
+                self.target_temperature,
+            ),
+            return_inputs=return_inputs,
         )
 
     def transient_temperature(
-        self, forecast_control: ThermalForecastArray | None = None
+        self,
+        forecast_control: ThermalForecastArray | None = None,
+        return_inputs: bool = True,
     ) -> ThermalTransientResults:
         """Compute transient temperature results.
 
@@ -589,7 +625,10 @@ class ThermalEngine:
             self.forecast = forecast_control
 
         return ThermalTransientResults(
-            self.thermal_model.transient_temperature(offset=self.forecast.time)
+            self.thermal_model.transient_temperature(
+                offset=self.forecast.time
+            ),
+            return_inputs=return_inputs,
         )
 
     @property

--- a/src/mechaphlowers/core/models/cable/thermal.py
+++ b/src/mechaphlowers/core/models/cable/thermal.py
@@ -32,7 +32,7 @@ class ThermalResults(ABC):
         return_inputs: bool = True,
     ):
         results = self.parse_results(input_data)
-        inputs = self._pop_inputs(results)  # noqa: S2259
+        inputs = self._pop_inputs(results)
         self.inputs = inputs if return_inputs else None
         self.data = results
 
@@ -56,7 +56,9 @@ class ThermalResults(ABC):
         return self.data.to_string()
 
     def __copy__(self) -> Self:
-        return type(self)(self.data)
+        copy = type(self)(self.data, return_inputs=False)
+        copy.inputs = self.inputs.copy() if self.inputs is not None else None
+        return copy
 
     def __repr__(self) -> str:
         class_name = type(self).__name__
@@ -83,14 +85,6 @@ class ThermalResults(ABC):
 
 class ThermalTransientResults(ThermalResults):
     """Thermal transient results class for transient temperature calculations."""
-
-    def __init__(self, input_data: dict | pd.DataFrame, *args, **kwargs):
-        """Initialize transient thermal results.
-
-        Args:
-            input_data (dict | pd.DataFrame): Raw transient thermal results data.
-        """
-        super().__init__(input_data, *args, **kwargs)
 
     @staticmethod
     def parse_results(data: dict | pd.DataFrame) -> pd.DataFrame:
@@ -129,14 +123,6 @@ class ThermalTransientResults(ThermalResults):
 
 class ThermalSteadyResults(ThermalResults):
     """Thermal steady-state results parser."""
-
-    def __init__(self, input_data: dict | pd.DataFrame, *args, **kwargs):
-        """Initialize steady-state thermal results.
-
-        Args:
-            input_data (dict | pd.DataFrame): Raw steady-state thermal results data.
-        """
-        super().__init__(input_data, *args, **kwargs)
 
     @staticmethod
     def parse_results(

--- a/src/mechaphlowers/core/models/cable/thermal.py
+++ b/src/mechaphlowers/core/models/cable/thermal.py
@@ -31,9 +31,9 @@ class ThermalResults(ABC):
         input_data: dict | pd.DataFrame,
         return_inputs: bool = True,
     ):
-        results = self.parse_results(input_data)
-        inputs = self._pop_inputs(results)
+        inputs = self._pop_inputs(input_data)
         self.inputs = inputs if return_inputs else None
+        results = self.parse_results(input_data)
         self.data = results
 
     @staticmethod
@@ -73,13 +73,31 @@ class ThermalResults(ABC):
         ]
 
     @classmethod
-    def _pop_inputs(cls, df: pd.DataFrame) -> pd.DataFrame:
-        input_columns = cls._input_columns(df)
-        inputs = df[input_columns]
-        df.drop(columns=input_columns, inplace=True)
-        inputs.rename(
-            columns=lambda s: s.replace(cls.INPUT_PREFIX, ""), inplace=True
-        )
+    def _input_keys(cls, data: dict) -> list[str]:
+        return [key for key in data.keys() if key.startswith(cls.INPUT_PREFIX)]
+
+    @classmethod
+    def _remove_input_prefix(cls, key: str) -> str:
+        return key.replace(cls.INPUT_PREFIX, "")
+
+    @classmethod
+    def _pop_inputs(cls, data: dict | pd.DataFrame) -> pd.DataFrame:
+        if isinstance(data, dict):
+            input_keys = cls._input_keys(data)
+            inputs = pd.DataFrame(
+                {
+                    cls._remove_input_prefix(key): value
+                    for key, value in data.items()
+                    if key in input_keys
+                }
+            )
+            for key in input_keys:
+                data.pop(key)
+        else:
+            input_columns = cls._input_columns(data)
+            inputs = data[input_columns]
+            data.drop(columns=input_columns, inplace=True)
+            inputs.rename(columns=cls._remove_input_prefix, inplace=True)
         return inputs
 
 

--- a/src/mechaphlowers/core/models/cable/thermal.py
+++ b/src/mechaphlowers/core/models/cable/thermal.py
@@ -47,7 +47,7 @@ class ThermalResults(ABC):
         Returns:
             pd.DataFrame: Parsed results as a pandas DataFrame.
         """
-        pass
+        raise NotImplementedError
 
     def __len__(self) -> int:
         return len(self.data)

--- a/src/mechaphlowers/core/models/cable/thermal.py
+++ b/src/mechaphlowers/core/models/cable/thermal.py
@@ -186,6 +186,9 @@ class SteadyTemperatureResults(ThermalSteadyResults):
 class SolarRadiationResults(ThermalResults):
     """Diffuse and beam radiations with their sum."""
 
+    def __init__(self, input_data):
+        self.data = self.parse_results(input_data)
+
     @staticmethod
     def parse_results(data: dict | pd.DataFrame) -> pd.DataFrame:
         if isinstance(data, pd.DataFrame):

--- a/src/mechaphlowers/core/models/cable/thermal.py
+++ b/src/mechaphlowers/core/models/cable/thermal.py
@@ -13,7 +13,6 @@ from typing import Any
 import numpy as np
 import pandas as pd
 from thermohl import solver  # type: ignore
-from typing_extensions import Self
 
 from mechaphlowers.entities.arrays import CableArray
 from mechaphlowers.entities.errors import UncertaintyNotAvailable
@@ -54,11 +53,6 @@ class ThermalResults(ABC):
 
     def __str__(self) -> str:
         return self.data.to_string()
-
-    def __copy__(self) -> Self:
-        copy = type(self)(self.data, return_inputs=False)
-        copy.inputs = self.inputs.copy() if self.inputs is not None else None
-        return copy
 
     def __repr__(self) -> str:
         class_name = type(self).__name__
@@ -581,6 +575,9 @@ class ThermalEngine:
     ) -> SteadyTemperatureResults:
         """Compute steady-state temperature results.
 
+        If return_inputs=True, input data are returned in
+        result.inputs as a DataFrame.
+
         Returns:
             SteadyTemperatureResults: An instance containing steady-state temperature data.
         """
@@ -602,6 +599,9 @@ class ThermalEngine:
     ) -> SteadyIntensityResults:
         """Compute steady-state intensity results.
 
+        If return_inputs=True, input data are returned in
+        result.inputs as a DataFrame.
+
         Returns:
             SteadyIntensityResults: An instance containing steady-state intensity data.
         """
@@ -621,6 +621,9 @@ class ThermalEngine:
         return_inputs: bool = True,
     ) -> ThermalTransientResults:
         """Compute transient temperature results.
+
+        If return_inputs=True, input data are returned in
+        result.inputs as a DataFrame.
 
         Returns:
             ThermalTransientResults: An instance containing time-varying temperature data.

--- a/test/core/models/cable/test_thermal.py
+++ b/test/core/models/cable/test_thermal.py
@@ -173,6 +173,42 @@ def test_steady_intensity(thermal_engine_3_spans: ThermalEngine):
     ).all()
 
 
+def test_steady_intensity_return_inputs(thermal_engine_3_spans) -> None:
+    thermal_engine = thermal_engine_3_spans
+
+    results_with_inputs = thermal_engine.steady_intensity(
+        target_temperature=100, return_inputs=True
+    )
+    results_with_inputs_implicit = thermal_engine.steady_intensity(
+        target_temperature=100
+    )
+    results_without_inputs = thermal_engine.steady_intensity(
+        target_temperature=100, return_inputs=False
+    )
+
+    assert not any(
+        column.startswith("input_")
+        for column in results_with_inputs.data.columns
+    )
+    assert results_with_inputs.inputs is not None
+
+    assert not any(
+        column.startswith("input_")
+        for column in results_with_inputs_implicit.data.columns
+    )
+    assert results_with_inputs_implicit.inputs is not None
+
+    assert not any(
+        column.startswith("input_")
+        for column in results_without_inputs.data.columns
+    )
+    assert results_with_inputs.inputs is not None
+
+    assert len(results_with_inputs.data.columns) == len(
+        results_without_inputs.data.columns
+    )
+
+
 def test_steady_temperature(thermal_engine_3_spans: ThermalEngine):
     thermal_engine = thermal_engine_3_spans
 
@@ -198,6 +234,38 @@ def test_steady_temperature(thermal_engine_3_spans: ThermalEngine):
         ).data["core_temperature"]
         > copy_result_without_input["core_temperature"]
     ).all()
+
+
+def test_steady_temperature_return_inputs(thermal_engine_3_spans) -> None:
+    thermal_engine = thermal_engine_3_spans
+
+    results_with_inputs = thermal_engine.steady_temperature(return_inputs=True)
+    results_with_inputs_implicit = thermal_engine.steady_temperature()
+    results_without_inputs = thermal_engine.steady_temperature(
+        return_inputs=False
+    )
+
+    assert not any(
+        column.startswith("input_")
+        for column in results_with_inputs.data.columns
+    )
+    assert results_with_inputs.inputs is not None
+
+    assert not any(
+        column.startswith("input_")
+        for column in results_with_inputs_implicit.data.columns
+    )
+    assert results_with_inputs_implicit.inputs is not None
+
+    assert not any(
+        column.startswith("input_")
+        for column in results_without_inputs.data.columns
+    )
+    assert results_with_inputs.inputs is not None
+
+    assert len(results_with_inputs.data.columns) == len(
+        results_without_inputs.data.columns
+    )
 
 
 def test_steady_temperature_with_uncertainty(
@@ -413,6 +481,40 @@ def test_transient_thermal(cable_array_AM600: CableArray):
 
     np.testing.assert_array_almost_equal(
         thermal_engine.wind_cable_angle, np.array([90.0, 80.0, 70.0])
+    )
+
+
+def test_transient_temperature_return_inputs(thermal_engine_3_spans) -> None:
+    thermal_engine = thermal_engine_3_spans
+
+    results_with_inputs = thermal_engine.transient_temperature(
+        return_inputs=True
+    )
+    results_with_inputs_implicit = thermal_engine.transient_temperature()
+    results_without_inputs = thermal_engine.transient_temperature(
+        return_inputs=False
+    )
+
+    assert not any(
+        column.startswith("input_")
+        for column in results_with_inputs.data.columns
+    )
+    assert results_with_inputs.inputs is not None
+
+    assert not any(
+        column.startswith("input_")
+        for column in results_with_inputs_implicit.data.columns
+    )
+    assert results_with_inputs_implicit.inputs is not None
+
+    assert not any(
+        column.startswith("input_")
+        for column in results_without_inputs.data.columns
+    )
+    assert results_with_inputs.inputs is not None
+
+    assert len(results_with_inputs.data.columns) == len(
+        results_without_inputs.data.columns
     )
 
 

--- a/test/core/models/cable/test_thermal.py
+++ b/test/core/models/cable/test_thermal.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 
+from copy import copy
 from datetime import datetime
 
 import numpy as np
@@ -593,3 +594,24 @@ def test_transient_results_raise_for_df_input():
         match="DataFrame input not supported for transient results parsing.",
     ):
         ThermalTransientResults.parse_results(df_input)
+
+
+def test_thermal_results_copy(thermal_engine_3_spans: ThermalEngine):
+    results_with_inputs = thermal_engine_3_spans.steady_temperature(
+        return_inputs=True
+    )
+    results_with_inputs_copy = copy(results_with_inputs)
+    assert (
+        results_with_inputs_copy.inputs.columns  # type: ignore
+        == results_with_inputs.inputs.columns  # type: ignore
+    ).all()
+
+    # Changing the copy's inputs doesn't change the original inputs
+    results_with_inputs_copy.inputs["nebulosity"] = np.array([-1, -1, -1])  # type: ignore
+    assert results_with_inputs.inputs["nebulosity"][0] != -1  # type: ignore
+
+    results_without_inputs = thermal_engine_3_spans.steady_temperature(
+        return_inputs=False
+    )
+    results_without_inputs_copy = copy(results_without_inputs)
+    assert results_without_inputs_copy.inputs is None

--- a/test/core/models/cable/test_thermal.py
+++ b/test/core/models/cable/test_thermal.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 
-from copy import copy
 from datetime import datetime
 
 import numpy as np
@@ -492,27 +491,6 @@ def test_transient_results_raise_for_df_input():
         match="DataFrame input not supported for transient results parsing.",
     ):
         ThermalTransientResults.parse_results(df_input)
-
-
-def test_thermal_results_copy(thermal_engine_3_spans: ThermalEngine):
-    results_with_inputs = thermal_engine_3_spans.steady_temperature(
-        return_inputs=True
-    )
-    results_with_inputs_copy = copy(results_with_inputs)
-    assert (
-        results_with_inputs_copy.inputs.columns  # type: ignore
-        == results_with_inputs.inputs.columns  # type: ignore
-    ).all()
-
-    # Changing the copy's inputs doesn't change the original inputs
-    results_with_inputs_copy.inputs["nebulosity"] = np.array([-1, -1, -1])  # type: ignore
-    assert results_with_inputs.inputs["nebulosity"][0] != -1  # type: ignore
-
-    results_without_inputs = thermal_engine_3_spans.steady_temperature(
-        return_inputs=False
-    )
-    results_without_inputs_copy = copy(results_without_inputs)
-    assert results_without_inputs_copy.inputs is None
 
 
 def assert_no_inputs_in_results(results):

--- a/test/core/models/cable/test_thermal.py
+++ b/test/core/models/cable/test_thermal.py
@@ -174,40 +174,38 @@ def test_steady_intensity(thermal_engine_3_spans: ThermalEngine):
     ).all()
 
 
+def assert_no_inputs_in_results(results):
+    assert not any(
+        column.startswith("input_") for column in results.data.columns
+    )
+    assert results.inputs is None
+
+
+def assert_inputs_in_results(results):
+    assert not any(
+        column.startswith("input_") for column in results.data.columns
+    )
+    assert results.inputs is not None
+    assert not results.inputs.empty
+
+
 def test_steady_intensity_return_inputs(thermal_engine_3_spans) -> None:
     thermal_engine = thermal_engine_3_spans
 
     results_with_inputs = thermal_engine.steady_intensity(
-        target_temperature=100, return_inputs=True
+        target_temperature=100
     )
+    assert_inputs_in_results(results_with_inputs)
+
     results_with_inputs_implicit = thermal_engine.steady_intensity(
         target_temperature=100
     )
+    assert_inputs_in_results(results_with_inputs_implicit)
+
     results_without_inputs = thermal_engine.steady_intensity(
-        target_temperature=100, return_inputs=False
+        target_temperature=100
     )
-
-    assert not any(
-        column.startswith("input_")
-        for column in results_with_inputs.data.columns
-    )
-    assert results_with_inputs.inputs is not None
-
-    assert not any(
-        column.startswith("input_")
-        for column in results_with_inputs_implicit.data.columns
-    )
-    assert results_with_inputs_implicit.inputs is not None
-
-    assert not any(
-        column.startswith("input_")
-        for column in results_without_inputs.data.columns
-    )
-    assert results_with_inputs.inputs is not None
-
-    assert len(results_with_inputs.data.columns) == len(
-        results_without_inputs.data.columns
-    )
+    assert_no_inputs_in_results(results_without_inputs)
 
 
 def test_steady_temperature(thermal_engine_3_spans: ThermalEngine):
@@ -241,32 +239,15 @@ def test_steady_temperature_return_inputs(thermal_engine_3_spans) -> None:
     thermal_engine = thermal_engine_3_spans
 
     results_with_inputs = thermal_engine.steady_temperature(return_inputs=True)
+    assert_inputs_in_results(results_with_inputs)
+
     results_with_inputs_implicit = thermal_engine.steady_temperature()
+    assert_inputs_in_results(results_with_inputs_implicit)
+
     results_without_inputs = thermal_engine.steady_temperature(
         return_inputs=False
     )
-
-    assert not any(
-        column.startswith("input_")
-        for column in results_with_inputs.data.columns
-    )
-    assert results_with_inputs.inputs is not None
-
-    assert not any(
-        column.startswith("input_")
-        for column in results_with_inputs_implicit.data.columns
-    )
-    assert results_with_inputs_implicit.inputs is not None
-
-    assert not any(
-        column.startswith("input_")
-        for column in results_without_inputs.data.columns
-    )
-    assert results_with_inputs.inputs is not None
-
-    assert len(results_with_inputs.data.columns) == len(
-        results_without_inputs.data.columns
-    )
+    assert_no_inputs_in_results(results_without_inputs)
 
 
 def test_steady_temperature_with_uncertainty(
@@ -491,32 +472,15 @@ def test_transient_temperature_return_inputs(thermal_engine_3_spans) -> None:
     results_with_inputs = thermal_engine.transient_temperature(
         return_inputs=True
     )
+    assert_inputs_in_results(results_with_inputs)
+
     results_with_inputs_implicit = thermal_engine.transient_temperature()
+    assert_inputs_in_results(results_with_inputs_implicit)
+
     results_without_inputs = thermal_engine.transient_temperature(
         return_inputs=False
     )
-
-    assert not any(
-        column.startswith("input_")
-        for column in results_with_inputs.data.columns
-    )
-    assert results_with_inputs.inputs is not None
-
-    assert not any(
-        column.startswith("input_")
-        for column in results_with_inputs_implicit.data.columns
-    )
-    assert results_with_inputs_implicit.inputs is not None
-
-    assert not any(
-        column.startswith("input_")
-        for column in results_without_inputs.data.columns
-    )
-    assert results_with_inputs.inputs is not None
-
-    assert len(results_with_inputs.data.columns) == len(
-        results_without_inputs.data.columns
-    )
+    assert_no_inputs_in_results(results_without_inputs)
 
 
 def test_nebulosity_variation(cable_array_AM600: CableArray):

--- a/test/core/models/cable/test_thermal.py
+++ b/test/core/models/cable/test_thermal.py
@@ -174,40 +174,6 @@ def test_steady_intensity(thermal_engine_3_spans: ThermalEngine):
     ).all()
 
 
-def assert_no_inputs_in_results(results):
-    assert not any(
-        column.startswith("input_") for column in results.data.columns
-    )
-    assert results.inputs is None
-
-
-def assert_inputs_in_results(results):
-    assert not any(
-        column.startswith("input_") for column in results.data.columns
-    )
-    assert results.inputs is not None
-    assert not results.inputs.empty
-
-
-def test_steady_intensity_return_inputs(thermal_engine_3_spans) -> None:
-    thermal_engine = thermal_engine_3_spans
-
-    results_with_inputs = thermal_engine.steady_intensity(
-        target_temperature=100
-    )
-    assert_inputs_in_results(results_with_inputs)
-
-    results_with_inputs_implicit = thermal_engine.steady_intensity(
-        target_temperature=100
-    )
-    assert_inputs_in_results(results_with_inputs_implicit)
-
-    results_without_inputs = thermal_engine.steady_intensity(
-        target_temperature=100
-    )
-    assert_no_inputs_in_results(results_without_inputs)
-
-
 def test_steady_temperature(thermal_engine_3_spans: ThermalEngine):
     thermal_engine = thermal_engine_3_spans
 
@@ -233,21 +199,6 @@ def test_steady_temperature(thermal_engine_3_spans: ThermalEngine):
         ).data["core_temperature"]
         > copy_result_without_input["core_temperature"]
     ).all()
-
-
-def test_steady_temperature_return_inputs(thermal_engine_3_spans) -> None:
-    thermal_engine = thermal_engine_3_spans
-
-    results_with_inputs = thermal_engine.steady_temperature(return_inputs=True)
-    assert_inputs_in_results(results_with_inputs)
-
-    results_with_inputs_implicit = thermal_engine.steady_temperature()
-    assert_inputs_in_results(results_with_inputs_implicit)
-
-    results_without_inputs = thermal_engine.steady_temperature(
-        return_inputs=False
-    )
-    assert_no_inputs_in_results(results_without_inputs)
 
 
 def test_steady_temperature_with_uncertainty(
@@ -466,23 +417,6 @@ def test_transient_thermal(cable_array_AM600: CableArray):
     )
 
 
-def test_transient_temperature_return_inputs(thermal_engine_3_spans) -> None:
-    thermal_engine = thermal_engine_3_spans
-
-    results_with_inputs = thermal_engine.transient_temperature(
-        return_inputs=True
-    )
-    assert_inputs_in_results(results_with_inputs)
-
-    results_with_inputs_implicit = thermal_engine.transient_temperature()
-    assert_inputs_in_results(results_with_inputs_implicit)
-
-    results_without_inputs = thermal_engine.transient_temperature(
-        return_inputs=False
-    )
-    assert_no_inputs_in_results(results_without_inputs)
-
-
 def test_nebulosity_variation(cable_array_AM600: CableArray):
     # Checks that nebulosity is taken into account
     thermal_engine = ThermalEngine()
@@ -579,3 +513,77 @@ def test_thermal_results_copy(thermal_engine_3_spans: ThermalEngine):
     )
     results_without_inputs_copy = copy(results_without_inputs)
     assert results_without_inputs_copy.inputs is None
+
+
+def assert_no_inputs_in_results(results):
+    assert not any(
+        column.startswith("input_") for column in results.data.columns
+    )
+    assert results.inputs is None
+
+
+def assert_inputs_in_results(results):
+    assert not any(
+        column.startswith("input_") for column in results.data.columns
+    )
+    assert results.inputs is not None
+    assert not results.inputs.empty
+
+
+def test_steady_intensity_return_inputs(
+    thermal_engine_3_spans: ThermalEngine,
+) -> None:
+    target_temperature = np.array([100, 100, 100])
+
+    results_with_inputs = thermal_engine_3_spans.steady_intensity(
+        target_temperature=target_temperature,
+        return_inputs=True,
+    )
+    assert_inputs_in_results(results_with_inputs)
+
+    results_with_inputs_implicit = thermal_engine_3_spans.steady_intensity(
+        target_temperature=target_temperature,
+    )
+    assert_inputs_in_results(results_with_inputs_implicit)
+
+    results_without_inputs = thermal_engine_3_spans.steady_intensity(
+        target_temperature=target_temperature,
+        return_inputs=False,
+    )
+    assert_no_inputs_in_results(results_without_inputs)
+
+
+def test_steady_temperature_return_inputs(
+    thermal_engine_3_spans: ThermalEngine,
+) -> None:
+    results_with_inputs = thermal_engine_3_spans.steady_temperature(
+        return_inputs=True,
+    )
+    assert_inputs_in_results(results_with_inputs)
+
+    results_with_inputs_implicit = thermal_engine_3_spans.steady_temperature()
+    assert_inputs_in_results(results_with_inputs_implicit)
+
+    results_without_inputs = thermal_engine_3_spans.steady_temperature(
+        return_inputs=False,
+    )
+    assert_no_inputs_in_results(results_without_inputs)
+
+
+def test_transient_temperature_return_inputs(
+    thermal_engine_3_spans: ThermalEngine,
+) -> None:
+    results_with_inputs = thermal_engine_3_spans.transient_temperature(
+        return_inputs=True,
+    )
+    assert_inputs_in_results(results_with_inputs)
+
+    results_with_inputs_implicit = (
+        thermal_engine_3_spans.transient_temperature()
+    )
+    assert_inputs_in_results(results_with_inputs_implicit)
+
+    results_without_inputs = thermal_engine_3_spans.transient_temperature(
+        return_inputs=False,
+    )
+    assert_no_inputs_in_results(results_without_inputs)


### PR DESCRIPTION
- Add parameter `return_inputs` to `ThermalEngine.transient_temperature`, `.steady_temperature` and `.steady_intensity`. Default is `True`.

- Store (optional) input data in separate attribute `.inputs` in `ThermalResults`. It's `None` if no inputs were returned. 

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #457 

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
To access input data in the results of `ThermalEngine.transient_temperature`, `.steady_temperature` or
`.steady_intensity`, you must now type `results.inputs`. They are now longer stored in `results.data`. Example:
```python
# Before
results = thermal_engine.steady_temperature()
results.data["input_latitude"]

# After
results = thermal_engine.steady_temperature()
results.inputs["latitude"]
```
