### PR TITLE
feat(#458): Cable temperature and cable type

### DIFF
--- a/src/mechaphlowers/core/models/cable/thermal.py
+++ b/src/mechaphlowers/core/models/cable/thermal.py
@@ -59,6 +59,11 @@ class ThermalResults(ABC):
         raise NotImplementedError
 
     def cable_temperature(self) -> np.ndarray:
+        """Relevant cable temperature for each span.
+
+        This means core temperature for bimetallic cables and average temperature
+        for homogenous cables.
+        """
         return np.where(
             self.cable_is_bimetallic,
             self.data["core_temperature"],

--- a/src/mechaphlowers/core/models/cable/thermal.py
+++ b/src/mechaphlowers/core/models/cable/thermal.py
@@ -36,12 +36,14 @@ class ThermalResults(ABC):
     def __init__(
         self,
         input_data: dict | pd.DataFrame,
+        cable_is_bimetallic: npt.NDArray[np.bool],
         return_inputs: bool = True,
     ):
         inputs = self._pop_inputs(input_data)
         self.inputs = inputs if return_inputs else None
         results = self.parse_results(input_data)
         self.data = results
+        self.cable_is_bimetallic = cable_is_bimetallic
 
     @staticmethod
     @abstractmethod
@@ -55,6 +57,13 @@ class ThermalResults(ABC):
             pd.DataFrame: Parsed results as a pandas DataFrame.
         """
         raise NotImplementedError
+
+    def cable_temperature(self) -> np.ndarray:
+        return np.where(
+            self.cable_is_bimetallic,
+            self.data["core_temperature"],
+            self.data["average_temperature"],
+        )
 
     def __len__(self) -> int:
         return len(self.data)
@@ -403,6 +412,7 @@ class ThermalEngine:
                 0.016 if cable_array.data.has_magnetic_heart.iloc[0] else 0.0,
             ),
         }
+        self.bimetallic_cable = cable_array.is_bimetallic
         self._load()
         logger.debug("Thermal attribute set")
 
@@ -442,6 +452,7 @@ class ThermalEngine:
             self.thermal_model.steady_temperature(
                 return_uncertainty=return_uncertainty,
             ),
+            cable_is_bimetallic=self.bimetallic_cable,
             return_inputs=return_inputs,
         )
 
@@ -465,6 +476,7 @@ class ThermalEngine:
             self.thermal_model.steady_intensity(
                 self.target_temperature,
             ),
+            cable_is_bimetallic=self.bimetallic_cable,
             return_inputs=return_inputs,
         )
 
@@ -488,6 +500,7 @@ class ThermalEngine:
             self.thermal_model.transient_temperature(
                 offset=self.forecast.time
             ),
+            cable_is_bimetallic=self.bimetallic_cable,
             return_inputs=return_inputs,
         )
 

--- a/src/mechaphlowers/core/models/cable/thermal.py
+++ b/src/mechaphlowers/core/models/cable/thermal.py
@@ -62,7 +62,7 @@ class ThermalResults(ABC):
         """Relevant cable temperature for each span.
 
         This means core temperature for bimetallic cables and average temperature
-        for homogenous cables.
+        for homogeneous cables.
         """
         return np.where(
             self.cable_is_bimetallic,

--- a/src/mechaphlowers/entities/arrays.py
+++ b/src/mechaphlowers/entities/arrays.py
@@ -848,6 +848,12 @@ class CableArray(ElementArray):
             ]
         )
 
+    @property
+    def is_bimetallic(self) -> npt.NDArray[np.bool]:
+        return ~np.isclose(
+            self.data["section_heart"].to_numpy(), 0, atol=0.0001
+        )
+
 
 class WeatherArray(ElementArray):
     """Weather-related data, such as wind and ice.

--- a/src/mechaphlowers/entities/arrays.py
+++ b/src/mechaphlowers/entities/arrays.py
@@ -850,6 +850,7 @@ class CableArray(ElementArray):
 
     @property
     def is_bimetallic(self) -> npt.NDArray[np.bool]:
+        """Whether the cable is bimetallic."""
         return ~np.isclose(
             self.data["section_heart"].to_numpy(), 0, atol=0.0001
         )

--- a/test/core/models/cable/test_thermal.py
+++ b/test/core/models/cable/test_thermal.py
@@ -52,6 +52,40 @@ def thermal_engine_3_spans(cable_array_AM600: CableArray) -> ThermalEngine:
     return thermal_engine
 
 
+@pytest.fixture
+def thermal_engine_3_spans_narcisse(
+    cable_array_NARCISSE600G: CableArray,
+) -> ThermalEngine:
+    thermal_engine = ThermalEngine()
+
+    thermal_engine.set(
+        cable_array_NARCISSE600G,
+        latitude=np.array([45.0, 45.0, 45.0]),
+        longitude=np.array([0.0, 0.0, 0.0]),
+        altitude=np.array([0.0, 0.0, 0.0]),
+        azimuth=np.array([0.0, 0.0, 90.0]),
+        datetime_utc=np.array(
+            [
+                np.datetime64("2026-03-21T22:00:00"),
+                np.datetime64("2026-03-21T22:00:00"),
+                np.datetime64("2026-03-21T12:00:00"),
+            ]
+        ),
+        intensity=np.array([100.0, 1000.0, 1000.0]),
+        ambient_temp=np.array([15.0, 15.0, 15.0]),
+        wind_speed=np.array([10.0, 1.0, 1.0]),
+        wind_angle=np.array(
+            [
+                90.0,
+                90.0,
+                90.0,
+            ]
+        ),
+        nebulosity=np.array([0, 0, 0]),
+    )
+    return thermal_engine
+
+
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_thermohl_cable_temp_arrays(cable_array_AM600: CableArray):
     thermal_engine = ThermalEngine()
@@ -135,6 +169,46 @@ def test_steady_intensity(thermal_engine_3_spans: ThermalEngine):
     ).all()
 
 
+def test_steady_intensity_cable_temperature(
+    thermal_engine_3_spans, thermal_engine_3_spans_narcisse
+) -> None:
+    thermal_engine_homogenous = thermal_engine_3_spans
+    results_homogenous = thermal_engine_homogenous.steady_intensity(
+        target_temperature=100
+    )
+    cable_temperature_homogenous = results_homogenous.cable_temperature()
+    np.testing.assert_allclose(
+        cable_temperature_homogenous,
+        results_homogenous.data["average_temperature"],
+    )
+    assert not np.allclose(
+        cable_temperature_homogenous,
+        results_homogenous.data["surface_temperature"],
+    )
+    assert not np.allclose(
+        cable_temperature_homogenous,
+        results_homogenous.data["core_temperature"],
+    )
+
+    thermal_engine_bimetallic = thermal_engine_3_spans_narcisse
+    results_bimetallic = thermal_engine_bimetallic.steady_intensity(
+        target_temperature=100
+    )
+    cable_temperature_bimetallic = results_bimetallic.cable_temperature()
+    np.testing.assert_allclose(
+        cable_temperature_bimetallic,
+        results_bimetallic.data["core_temperature"],
+    )
+    assert not np.allclose(
+        cable_temperature_bimetallic,
+        results_bimetallic.data["surface_temperature"],
+    )
+    assert not np.allclose(
+        cable_temperature_bimetallic,
+        results_bimetallic.data["average_temperature"],
+    )
+
+
 def test_steady_temperature(thermal_engine_3_spans: ThermalEngine):
     thermal_engine = thermal_engine_3_spans
 
@@ -193,6 +267,43 @@ def test_steady_temperature_without_uncertainty_explicit(
     with pytest.raises(UncertaintyNotAvailable) as e:
         results.uncertainty
         print(e)
+
+
+def test_steady_temperature_cable_temperature(
+    thermal_engine_3_spans: ThermalEngine,
+    thermal_engine_3_spans_narcisse: ThermalEngine,
+) -> None:
+    thermal_engine_homogenous = thermal_engine_3_spans
+    results_homogenous = thermal_engine_homogenous.steady_temperature()
+    cable_temperature_homogenous = results_homogenous.cable_temperature()
+    np.testing.assert_allclose(
+        cable_temperature_homogenous,
+        results_homogenous.data["average_temperature"],
+    )
+    assert not np.allclose(
+        cable_temperature_homogenous,
+        results_homogenous.data["surface_temperature"],
+    )
+    assert not np.allclose(
+        cable_temperature_homogenous,
+        results_homogenous.data["core_temperature"],
+    )
+
+    thermal_engine_bimetallic = thermal_engine_3_spans_narcisse
+    results_bimetallic = thermal_engine_bimetallic.steady_temperature()
+    cable_temperature_bimetallic = results_bimetallic.cable_temperature()
+    np.testing.assert_allclose(
+        cable_temperature_bimetallic,
+        results_bimetallic.data["core_temperature"],
+    )
+    assert not np.allclose(
+        cable_temperature_bimetallic,
+        results_bimetallic.data["surface_temperature"],
+    )
+    assert not np.allclose(
+        cable_temperature_bimetallic,
+        results_bimetallic.data["average_temperature"],
+    )
 
 
 def test_wrong_array_length(cable_array_AM600: CableArray):
@@ -301,6 +412,43 @@ def test_transient_thermal(cable_array_AM600: CableArray):
 
     np.testing.assert_array_almost_equal(
         thermal_engine.wind_cable_angle, np.array([90.0, 80.0, 70.0])
+    )
+
+
+def test_transient_temperature_cable_temperature(
+    thermal_engine_3_spans: ThermalEngine,
+    thermal_engine_3_spans_narcisse: ThermalEngine,
+) -> None:
+    thermal_engine_homogenous = thermal_engine_3_spans
+    results_homogenous = thermal_engine_homogenous.transient_temperature()
+    cable_temperature_homogenous = results_homogenous.cable_temperature()
+    np.testing.assert_allclose(
+        cable_temperature_homogenous,
+        results_homogenous.data["average_temperature"],
+    )
+    assert not np.allclose(
+        cable_temperature_homogenous,
+        results_homogenous.data["surface_temperature"],
+    )
+    assert not np.allclose(
+        cable_temperature_homogenous,
+        results_homogenous.data["core_temperature"],
+    )
+
+    thermal_engine_bimetallic = thermal_engine_3_spans_narcisse
+    results_bimetallic = thermal_engine_bimetallic.steady_temperature()
+    cable_temperature_bimetallic = results_bimetallic.cable_temperature()
+    np.testing.assert_allclose(
+        cable_temperature_bimetallic,
+        results_bimetallic.data["core_temperature"],
+    )
+    assert not np.allclose(
+        cable_temperature_bimetallic,
+        results_bimetallic.data["surface_temperature"],
+    )
+    assert not np.allclose(
+        cable_temperature_bimetallic,
+        results_bimetallic.data["average_temperature"],
     )
 
 

--- a/test/core/models/cable/test_thermal.py
+++ b/test/core/models/cable/test_thermal.py
@@ -436,7 +436,7 @@ def test_transient_temperature_cable_temperature(
     )
 
     thermal_engine_bimetallic = thermal_engine_3_spans_narcisse
-    results_bimetallic = thermal_engine_bimetallic.steady_temperature()
+    results_bimetallic = thermal_engine_bimetallic.transient_temperature()
     cable_temperature_bimetallic = results_bimetallic.cable_temperature()
     np.testing.assert_allclose(
         cable_temperature_bimetallic,

--- a/test/entities/test_cable_array.py
+++ b/test/entities/test_cable_array.py
@@ -4,6 +4,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # SPDX-License-Identifier: MPL-2.0
 
+import numpy as np
 import pandas as pd
 import pandera as pa
 import pytest
@@ -259,3 +260,10 @@ def test_cable_mecha_thermal_data(cable_array_input_data: dict):
         check_like=True,
         atol=1e-07,
     )
+
+
+def test_cable_array_is_bimetallic(
+    cable_array_AM600, cable_array_NARCISSE600G
+) -> None:
+    assert (cable_array_AM600.is_bimetallic == np.array([False])).all()
+    assert (cable_array_NARCISSE600G.is_bimetallic == np.array([True])).all()


### PR DESCRIPTION
To be merged after #465 

- Add .is_bimetallic to CableArray, based on following rule: a cable is bimetallic <=> it has a non-zero section_heart
- Expose cable_temperature in results based on cable type: Core temperature for bimetallic cables, average temperature
            for homogenous cables.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #458 
NB: this slightly differs from what was described in the issue.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
