### PR TITLE
docs: Fix docstrings about set_loads.

### DIFF
--- a/src/mechaphlowers/core/models/balance/engine.py
+++ b/src/mechaphlowers/core/models/balance/engine.py
@@ -217,7 +217,6 @@ class BalanceEngine(Notifier):
         Input for position is a distance, and will be converted into ratio.
 
         Expected input are arrays of size matching the number of spans. Each value refers to a span.
-        Last elements should be nan or zero.
 
         If either load_position_distance[i] or load_mass[i] is 0 or nan, it means there is no load at span i.
 

--- a/src/mechaphlowers/core/models/balance/span_loads.py
+++ b/src/mechaphlowers/core/models/balance/span_loads.py
@@ -36,7 +36,7 @@ class SpanLoads:
 
         Warning: expected lengths for the arguments are different. Expected length of load_position_distance and
         load_mass is the number of spans. Each value refers to a span. Expected length of span_length is the number
-        of pylons (same as SectionArray.data.span_length). Last element should be nan or zero.
+        of pylons (same as SectionArray.data.span_length). Last element of span_length should be nan or zero.
 
         If either load_position_distance[i] or load_mass[i] is 0 or nan, it means there is no load at span i.
 

--- a/src/mechaphlowers/core/models/balance/span_loads.py
+++ b/src/mechaphlowers/core/models/balance/span_loads.py
@@ -34,9 +34,9 @@ class SpanLoads:
 
         Input for position is a distance, and will be converted into ratio.
 
-        Expected length of load_position_distance and load_mass is the number of spans. Each value refers to a span.
-        Last elements should be nan or zero. Expected length of span_length is the number of pylons (same as
-        SectionArray.data.span_length).
+        Warning: expected lengths for the arguments are different. Expected length of load_position_distance and
+        load_mass is the number of spans. Each value refers to a span. Expected length of span_length is the number
+        of pylons (same as SectionArray.data.span_length). Last element should be nan or zero.
 
         If either load_position_distance[i] or load_mass[i] is 0 or nan, it means there is no load at span i.
 


### PR DESCRIPTION
 I noticed a mistake in these docstrings.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
