### PR TITLE
Hotfix: loads saved by memento

### DIFF
--- a/src/mechaphlowers/api/section_study.py
+++ b/src/mechaphlowers/api/section_study.py
@@ -398,12 +398,20 @@ class SectionStudy:
         logger.debug("Intermediate warm-start solve at default conditions.")
         engine = self._balance_engine
         default = engine.default_value
-
-        engine.solve_change_state(
-            wind_pressure=default["wind_pressure"],
-            ice_thickness=default["ice_thickness"],
-            new_temperature=default["new_temperature"],
-        )
+        
+        memento = self._caretaker.save()
+        try:
+            engine.solve_change_state(
+                wind_pressure=default["wind_pressure"],
+                ice_thickness=default["ice_thickness"],
+                new_temperature=default["new_temperature"],
+            )
+        except SolverError as e:
+            logger.error(
+                "Error during solve_change_state, rolling back state."
+            )
+            self._caretaker.restore(memento)
+            raise e
         self._intermediate_memento = self._caretaker.save()
 
     def add_loads(

--- a/src/mechaphlowers/api/section_study.py
+++ b/src/mechaphlowers/api/section_study.py
@@ -398,7 +398,7 @@ class SectionStudy:
         logger.debug("Intermediate warm-start solve at default conditions.")
         engine = self._balance_engine
         default = engine.default_value
-        
+
         memento = self._caretaker.save()
         try:
             engine.solve_change_state(

--- a/src/mechaphlowers/api/section_study.py
+++ b/src/mechaphlowers/api/section_study.py
@@ -363,15 +363,17 @@ class SectionStudy:
 
         memento = self._caretaker.save()
         try:
-            if not is_default:
+            if is_default:
+                self._solve_intermediate()
+            else:
                 self._get_intermediate_state()
 
-            engine.solve_change_state(
-                wind_pressure=wind_pressure,
-                ice_thickness=ice_thickness,
-                new_temperature=new_temperature,
-                wind_direction=wind_direction,
-            )
+                engine.solve_change_state(
+                    wind_pressure=wind_pressure,
+                    ice_thickness=ice_thickness,
+                    new_temperature=new_temperature,
+                    wind_direction=wind_direction,
+                )
         except SolverError as e:
             logger.error(
                 "Error during solve_change_state, rolling back state."

--- a/src/mechaphlowers/api/section_study.py
+++ b/src/mechaphlowers/api/section_study.py
@@ -447,6 +447,7 @@ class SectionStudy:
                 or if the arguments don't have the right lengths.
         """
         self._balance_engine.set_loads(load_position_distance, load_mass)
+        self._solve_intermediate()
 
     # ── State management ──────────────────────────────────────────────────
 

--- a/src/mechaphlowers/core/geometry/points.py
+++ b/src/mechaphlowers/core/geometry/points.py
@@ -679,7 +679,7 @@ class CoordsCalculator:
             )
             # invert y axis to get more natural view
             x, y, z = new_points.vectors
-            new_points.coords = np.array([x, y, z]).T
+            new_points.coords = np.array([x, -y, z]).T
             result_points.append(new_points)
         return result_points
 

--- a/src/mechaphlowers/core/geometry/points.py
+++ b/src/mechaphlowers/core/geometry/points.py
@@ -679,7 +679,7 @@ class CoordsCalculator:
             )
             # invert y axis to get more natural view
             x, y, z = new_points.vectors
-            new_points.coords = np.array([x, -y, z]).T
+            new_points.coords = np.array([x, y, z]).T
             result_points.append(new_points)
         return result_points
 

--- a/src/mechaphlowers/core/models/balance/engine.py
+++ b/src/mechaphlowers/core/models/balance/engine.py
@@ -143,7 +143,8 @@ class BalanceEngine(Notifier):
                 sagging_temperature,
                 self.deformation_model_type,
             )
-            super().__init__()
+            if not hasattr(self, "_observers"):
+                super().__init__()
             self.balance_model = self.balance_model_type(
                 sagging_temperature,
                 parameter,

--- a/src/mechaphlowers/core/models/balance/models/model_ducloux.py
+++ b/src/mechaphlowers/core/models/balance/models/model_ducloux.py
@@ -154,6 +154,19 @@ class BalanceModel(IBalanceModel):
         self.initialize_loadmodel()
         self.initialize_solvers()
         self.initialize_state()
+        # Invalidate memoized merge indices: they depend on the load layout
+        # (nodes were rebuilt above) and must be recomputed on next use.
+        for attr in (
+            "_merge_normal_idx",
+            "_merge_left_idx",
+            "_merge_right_idx",
+            "_merge_not_load_mask",
+            "_merge_n_total",
+            "_merge_span_index",
+            "_merge_span_type",
+        ):
+            if hasattr(self, attr):
+                delattr(self, attr)
 
     def initialize_state(self):
         """Initialize the state of the model. Mainly used as a preprocess before a computation."""

--- a/src/mechaphlowers/core/models/balance/models/model_ducloux.py
+++ b/src/mechaphlowers/core/models/balance/models/model_ducloux.py
@@ -156,6 +156,15 @@ class BalanceModel(IBalanceModel):
         self.initialize_state()
         # Invalidate memoized merge indices: they depend on the load layout
         # (nodes were rebuilt above) and must be recomputed on next use.
+        self._invalidate_merge_cache()
+
+    def _invalidate_merge_cache(self) -> None:
+        """Drop the memoized merge indices used by merge_loads_to_span_model.
+
+        They depend on the load layout (``nodes.has_load_on_span``) and become
+        stale whenever that layout changes (reset, or memento restore). They
+        must be recomputed lazily on the next merge call.
+        """
         for attr in (
             "_merge_normal_idx",
             "_merge_left_idx",
@@ -660,6 +669,10 @@ class BalanceModel(IBalanceModel):
     def sync_after_memento_restore(
         self, span_model_to_mirror: ISpan, dxdydz: np.ndarray
     ):
+        # The restored memento may carry a different load layout than the one
+        # for which the merge indices were last computed. Invalidate the cache
+        # so merge_loads_to_span_model rebuilds it for the restored layout.
+        self._invalidate_merge_cache()
         self.nodes.dxdydz[:] = dxdydz
         self.nodes_span_model.mirror(span_model_to_mirror)
         self.nodes.compute_dx_dy_dz()

--- a/test/api/test_section_study_integration.py
+++ b/test/api/test_section_study_integration.py
@@ -232,19 +232,18 @@ def test_rope(study_8span: SectionStudy) -> None:
         expected_insulator_length,
     )
 
+
 @pytest.mark.integration
 def test_intermediate_state_should_refresh_after_load_addition(
-    study_8span: SectionStudy, study_8span_Lref: np.ndarray
+    study_8span: SectionStudy,
 ) -> None:
     """Add a load on support 5 and check that the intermediate state is refreshed."""
     study_8span.solve_adjustment()
     study_8span.solve_change_state(new_temperature=15.0)
 
-    intermediate_memento_0 = copy.copy(study_8span._intermediate_memento)
+    # intermediate_memento_0 = copy.copy(study_8span._intermediate_memento)
 
-    expected_load_mass = np.array(
-        [0.0, 0.0, 0.0, 0.0, 100.0, 0.0, 0.0, 0.0]
-    )
+    expected_load_mass = np.array([0.0, 0.0, 0.0, 0.0, 100.0, 0.0, 0.0, 0.0])
     expected_load_position = np.array(
         [0.0, 0.0, 0.0, 0.0, 250.0, 0.0, 0.0, 0.0]
     )
@@ -254,9 +253,9 @@ def test_intermediate_state_should_refresh_after_load_addition(
         load_mass=expected_load_mass,
     )
     intermediate_memento_1 = copy.copy(study_8span._intermediate_memento)
-    np.testing.assert_allclose(intermediate_memento_1.load_mass, expected_load_mass)
-
-
+    np.testing.assert_allclose(
+        intermediate_memento_1.load_mass, expected_load_mass
+    )
 
 
 @pytest.mark.integration
@@ -264,7 +263,7 @@ def test_reset_engine_breaks_reactivity_on_position_engine_after_climate_load_ad
     study_8span: SectionStudy,
 ) -> None:
     """Add a load on support 5 and check that the intermediate state is refreshed."""
-    
+
     # very important: full reset
     study_8span.balance_engine.reset(True)
 
@@ -272,15 +271,13 @@ def test_reset_engine_breaks_reactivity_on_position_engine_after_climate_load_ad
     study_8span.solve_adjustment()
     study_8span.solve_change_state(new_temperature=15.0)
     group_0 = study_8span.position_engine.get_group_points()
-    
+
     # 1. change state to a new temperature and wind pressure, which will break the intermediate state
     study_8span.solve_change_state(new_temperature=15.0, wind_pressure=300)
     group_1 = study_8span.position_engine.get_group_points()
 
-    # 2. add a load 
-    expected_load_mass = np.array(
-        [100.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-    )
+    # 2. add a load
+    expected_load_mass = np.array([100.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
     expected_load_position = np.array(
         [250.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     )
@@ -293,13 +290,15 @@ def test_reset_engine_breaks_reactivity_on_position_engine_after_climate_load_ad
 
     # should be different because the intermediate state is not refreshed after load addition
     with pytest.raises(AssertionError):
-        np.testing.assert_allclose(group_0.spans.coords[0], group_1.spans.coords[0])
-        np.testing.assert_allclose(group_1.spans.coords[0], group_2.spans.coords[0])
-        np.testing.assert_allclose(group_0.spans.coords[0], group_2.spans.coords[0])
-        
-
-
-
+        np.testing.assert_allclose(
+            group_0.spans.coords[0], group_1.spans.coords[0]
+        )
+        np.testing.assert_allclose(
+            group_1.spans.coords[0], group_2.spans.coords[0]
+        )
+        np.testing.assert_allclose(
+            group_0.spans.coords[0], group_2.spans.coords[0]
+        )
 
 
 @pytest.mark.integration

--- a/test/api/test_section_study_integration.py
+++ b/test/api/test_section_study_integration.py
@@ -4,6 +4,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # SPDX-License-Identifier: MPL-2.0
 
+import copy
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -229,6 +231,75 @@ def test_rope(study_8span: SectionStudy) -> None:
         study_8span.balance_engine.section_array.data["insulator_length"],
         expected_insulator_length,
     )
+
+@pytest.mark.integration
+def test_intermediate_state_refresh_after_load_addition(
+    study_8span: SectionStudy, study_8span_Lref: np.ndarray
+) -> None:
+    """Add a load on support 5 and check that the intermediate state is refreshed."""
+    study_8span.solve_adjustment()
+    study_8span.solve_change_state(new_temperature=15.0)
+
+    intermediate_memento_0 = copy.copy(study_8span._intermediate_memento)
+
+    expected_load_mass = np.array(
+        [0.0, 0.0, 0.0, 0.0, 100.0, 0.0, 0.0, 0.0]
+    )
+    expected_load_position = np.array(
+        [0.0, 0.0, 0.0, 0.0, 250.0, 0.0, 0.0, 0.0]
+    )
+
+    study_8span.set_loads(
+        load_position_distance=expected_load_position,
+        load_mass=expected_load_mass,
+    )
+    intermediate_memento_1 = copy.copy(study_8span._intermediate_memento)
+    np.testing.assert_allclose(intermediate_memento_1.load_mass, expected_load_mass)
+
+
+
+
+@pytest.mark.integration
+def test_reset_engine_breaks_reactivity_on_position_engine_after_climate_load_addition(
+    study_8span: SectionStudy,
+) -> None:
+    """Add a load on support 5 and check that the intermediate state is refreshed."""
+    
+    # very important: full reset
+    study_8span.balance_engine.reset(True)
+
+    # 0. solve adjustment and change state to initialize the intermediate state
+    study_8span.solve_adjustment()
+    study_8span.solve_change_state(new_temperature=15.0)
+    group_0 = study_8span.position_engine.get_group_points()
+    
+    # 1. change state to a new temperature and wind pressure, which will break the intermediate state
+    study_8span.solve_change_state(new_temperature=15.0, wind_pressure=300)
+    group_1 = study_8span.position_engine.get_group_points()
+
+    # 2. add a load 
+    expected_load_mass = np.array(
+        [100.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    )
+    expected_load_position = np.array(
+        [250.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    )
+
+    study_8span.set_loads(
+        load_position_distance=expected_load_position,
+        load_mass=expected_load_mass,
+    )
+    group_2 = study_8span.position_engine.get_group_points()
+
+    # should be different because the intermediate state is not refreshed after load addition
+    with pytest.raises(AssertionError):
+        np.testing.assert_allclose(group_0.spans.coords[0], group_1.spans.coords[0])
+        np.testing.assert_allclose(group_1.spans.coords[0], group_2.spans.coords[0])
+        np.testing.assert_allclose(group_0.spans.coords[0], group_2.spans.coords[0])
+        
+
+
+
 
 
 @pytest.mark.integration

--- a/test/api/test_section_study_integration.py
+++ b/test/api/test_section_study_integration.py
@@ -233,7 +233,7 @@ def test_rope(study_8span: SectionStudy) -> None:
     )
 
 @pytest.mark.integration
-def test_intermediate_state_refresh_after_load_addition(
+def test_intermediate_state_should_refresh_after_load_addition(
     study_8span: SectionStudy, study_8span_Lref: np.ndarray
 ) -> None:
     """Add a load on support 5 and check that the intermediate state is refreshed."""

--- a/test/api/test_section_study_integration.py
+++ b/test/api/test_section_study_integration.py
@@ -300,15 +300,9 @@ def test_reset_engine_breaks_reactivity_on_position_engine_after_climate_load_ad
     group_1_coords = group_1.spans.coords[0]
     group_2_coords = group_2.spans.coords[0]
     with pytest.raises(AssertionError):
-        np.testing.assert_allclose(
-            group_0_coords, group_1_coords
-        )
-        np.testing.assert_allclose(
-            group_1_coords, group_2_coords
-        )
-        np.testing.assert_allclose(
-            group_0_coords, group_2_coords
-        )
+        np.testing.assert_allclose(group_0_coords, group_1_coords)
+        np.testing.assert_allclose(group_1_coords, group_2_coords)
+        np.testing.assert_allclose(group_0_coords, group_2_coords)
 
 
 @pytest.mark.integration

--- a/test/api/test_section_study_integration.py
+++ b/test/api/test_section_study_integration.py
@@ -253,6 +253,7 @@ def test_intermediate_state_should_refresh_after_load_addition(
         load_mass=expected_load_mass,
     )
     intermediate_memento_1 = copy.copy(study_8span._intermediate_memento)
+    assert intermediate_memento_1 is not None
     np.testing.assert_allclose(
         intermediate_memento_1.load_mass, expected_load_mass
     )
@@ -289,15 +290,24 @@ def test_reset_engine_breaks_reactivity_on_position_engine_after_climate_load_ad
     group_2 = study_8span.position_engine.get_group_points()
 
     # should be different because the intermediate state is not refreshed after load addition
+    assert group_0 is not None
+    assert group_1 is not None
+    assert group_2 is not None
+    assert group_0.spans is not None
+    assert group_1.spans is not None
+    assert group_2.spans is not None
+    group_0_coords = group_0.spans.coords[0]
+    group_1_coords = group_1.spans.coords[0]
+    group_2_coords = group_2.spans.coords[0]
     with pytest.raises(AssertionError):
         np.testing.assert_allclose(
-            group_0.spans.coords[0], group_1.spans.coords[0]
+            group_0_coords, group_1_coords
         )
         np.testing.assert_allclose(
-            group_1.spans.coords[0], group_2.spans.coords[0]
+            group_1_coords, group_2_coords
         )
         np.testing.assert_allclose(
-            group_0.spans.coords[0], group_2.spans.coords[0]
+            group_0_coords, group_2_coords
         )
 
 

--- a/test/core/models/balance/test_engine_rollback.py
+++ b/test/core/models/balance/test_engine_rollback.py
@@ -107,7 +107,7 @@ class TestIntermediateState:
         # change state with non-default params — intermediate
         study.solve_change_state(wind_pressure=200, new_temperature=90)
         assert id(study.intermediate_memento) is not id(memento_0)
-        
-        #revert to default params — intermediate
+
+        # revert to default params — intermediate
         study.solve_change_state()
         assert id(study.intermediate_memento) is not id(memento_0)

--- a/test/core/models/balance/test_engine_rollback.py
+++ b/test/core/models/balance/test_engine_rollback.py
@@ -90,7 +90,7 @@ class TestIntermediateState:
         study.solve_change_state(wind_pressure=200, new_temperature=90)
         assert study.intermediate_memento is not None
 
-    def test_default_params_skip_intermediate(
+    def test_default_params_trigger_intermediate(
         self, balance_engine_base_test: BalanceEngine
     ):
         study = SectionStudy(
@@ -99,6 +99,15 @@ class TestIntermediateState:
         )
         study.solve_adjustment()
 
-        # Solve with defaults — no intermediate
+        # Solve with defaults — intermediate
         study.solve_change_state()
-        assert study.intermediate_memento is None
+        memento_0 = study.intermediate_memento
+        assert study.intermediate_memento is not None
+
+        # change state with non-default params — intermediate
+        study.solve_change_state(wind_pressure=200, new_temperature=90)
+        assert id(study.intermediate_memento) is not id(memento_0)
+        
+        #revert to default params — intermediate
+        study.solve_change_state()
+        assert id(study.intermediate_memento) is not id(memento_0)

--- a/test/core/models/balance/test_memento.py
+++ b/test/core/models/balance/test_memento.py
@@ -217,15 +217,11 @@ class TestCaretakerRestore:
         engine.set_loads([250, 0, 0], [70, 0, 0])
         engine.solve_change_state(new_temperature=60)
 
-        span_index_scratch = (
-            engine.balance_model.nodes_span_model.span_index
-        )
+        span_index_scratch = engine.balance_model.nodes_span_model.span_index
         span_type_scratch = engine.balance_model.nodes_span_model.span_type
         parameter_scratch = engine.balance_model.nodes_span_model.parameter
 
-        np.testing.assert_array_equal(
-            span_index_restore, span_index_scratch
-        )
+        np.testing.assert_array_equal(span_index_restore, span_index_scratch)
         np.testing.assert_array_equal(span_type_restore, span_type_scratch)
         np.testing.assert_array_almost_equal(
             parameter_restore, parameter_scratch

--- a/test/core/models/balance/test_memento.py
+++ b/test/core/models/balance/test_memento.py
@@ -167,3 +167,66 @@ class TestCaretakerRestore:
             engine.balance_model.nodes_span_model.parameter,
             engine.span_model.parameter,
         )
+
+    def test_restore_invalidates_merge_index_cache(
+        self, balance_engine_base_test: BalanceEngine
+    ):
+        """Restoring a memento with a different load layout must invalidate the
+        memoized merge-index cache (``_merge_*``).
+
+        The cache is only cleared on ``reset()``. When a memento captured with
+        one load layout is restored on top of a state whose cache was computed
+        for a *different* layout, ``merge_loads_to_span_model()`` would reuse
+        stale indices and produce a wrong ``span_index`` / ``span_type`` /
+        merged geometry. This test reproduces that behavior by comparing the
+        restore path against an independent from-scratch solve of the same
+        layout.
+        """
+        engine = balance_engine_base_test
+        engine.solve_adjustment()
+
+        # Layout A: a single load on the first span (span index 0).
+        engine.set_loads([250, 0, 0], [70, 0, 0])
+        memento_layout_a = BalanceEngineCaretaker(engine).save()
+
+        # Layout B: a single load on the last span (span index 2).
+        # Solving here populates the merge-index cache for layout B.
+        engine.set_loads([0, 0, 250], [0, 0, 70])
+        engine.solve_change_state(new_temperature=60)
+
+        # Restore layout A (updates has_load_on_span) then solve again.
+        # If the merge cache is not invalidated, the stale layout-B indices are
+        # reused and the merged span metadata is wrong.
+        caretaker = BalanceEngineCaretaker(engine)
+        caretaker.restore(memento_layout_a)
+        engine.solve_change_state(new_temperature=60)
+
+        span_index_restore = (
+            engine.balance_model.nodes_span_model.span_index.copy()
+        )
+        span_type_restore = (
+            engine.balance_model.nodes_span_model.span_type.copy()
+        )
+        parameter_restore = (
+            engine.balance_model.nodes_span_model.parameter.copy()
+        )
+
+        # Golden reference: solve layout A from scratch on a clean engine.
+        engine.reset(full=True)
+        engine.solve_adjustment()
+        engine.set_loads([250, 0, 0], [70, 0, 0])
+        engine.solve_change_state(new_temperature=60)
+
+        span_index_scratch = (
+            engine.balance_model.nodes_span_model.span_index
+        )
+        span_type_scratch = engine.balance_model.nodes_span_model.span_type
+        parameter_scratch = engine.balance_model.nodes_span_model.parameter
+
+        np.testing.assert_array_equal(
+            span_index_restore, span_index_scratch
+        )
+        np.testing.assert_array_equal(span_type_restore, span_type_scratch)
+        np.testing.assert_array_almost_equal(
+            parameter_restore, parameter_scratch
+        )

--- a/test/plotting/test_plot_reactivty.py
+++ b/test/plotting/test_plot_reactivty.py
@@ -309,8 +309,9 @@ class TestFullResetBehavior:
     def test_full_reset_clears_balance_engine_observer_registry(
         self, balance_engine_base_test: BalanceEngine
     ):
-        """reset(full=True) calls super().__init__() which resets _observers=[].
-        PositionEngine is no longer registered; callers must re-create PlotEngine."""
+        """reset(full=True) should NOT clear the observers registry.
+        PositionEngine must remain registered so PlotEngine continues
+        receiving notifications after a full reset."""
         plt_engine = PlotEngine(balance_engine_base_test)
         assert (
             plt_engine.position_engine in balance_engine_base_test._observers
@@ -318,10 +319,9 @@ class TestFullResetBehavior:
 
         balance_engine_base_test.reset(full=True)
 
-        assert balance_engine_base_test._observers == []
+        # Full reset must preserve observer registrations.
         assert (
-            plt_engine.position_engine
-            not in balance_engine_base_test._observers
+            plt_engine.position_engine in balance_engine_base_test._observers
         )
 
     def test_position_engine_reset_calls_initialize_engine_when_not_initialized(


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
Bugfix: set_loads now store loads in memento
Fix a bug where climage + loads will not affect loads 

Also fix bug to allow changing the number of loads